### PR TITLE
docs: improve ecosystem documentation and contribution experience

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Slack Channel
+    url: https://gsa.enterprise.slack.com/archives/C0B44531QLE
+    about: For quick questions and real-time discussion, ask in the agentic-coding Slack channel
+  - name: Agentic Coding Quickstart
+    url: https://github.com/GSA-TTS/agentic-coding-quickstart
+    about: For environment setup, SBX configuration, and getting started
+  - name: Agentic Coding Patterns
+    url: https://github.com/GSA-TTS/agentic-coding-patterns
+    about: For community patterns, workflows, and lessons learned

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,9 @@
 ---
-title: "Federal AI Agent Behavior Rules"
-description: "Master behavioral contract defining what AI coding agents MUST, SHOULD, and MAY do in federal development environments — includes meta-constraints, engineering discipline enforcement, and verification requirements"
+title: "Federal AI Agent Behavioral Best Practices"
+description: "Best practices for AI coding agent behavior in federal development environments — includes behavioral standards, engineering discipline enforcement, and verification requirements"
 status: canonical
 tier: 1
-last_updated: "2026-02-25"
+last_updated: "2026-05-21"
 nist_controls: ["AC-2", "AC-3", "AC-6", "AU-2", "AU-3", "AU-12", "CM-2", "CM-3", "CM-5", "CM-6", "CM-7", "IA-8", "IR-4", "IR-6", "PL-4", "SA-5", "SA-8", "SA-11", "SA-15", "SA-17", "SC-7", "SC-8", "SC-13", "SI-10", "SI-17", "SR-3"]
 frameworks: ["NIST SP 800-53 Rev 5.2", "NIST AI RMF 1.0", "NIST AI 600-1", "NCCOE Agent Identity", "OWASP Top 10 LLM 2025", "OWASP Top 10 Agentic 2026"]
 audience: "all"
@@ -13,9 +13,9 @@ load_priority: "always"
 review_cycle: "quarterly"
 ---
 
-<!-- LOAD: always — This is the core behavioral contract. Agents MUST load this document for every task. -->
+<!-- LOAD: always — This is the core behavioral best practices document. Agents MUST load this document for every task. -->
 
-# AGENTS.md — Federal AI Agent Behavior Rules
+# AGENTS.md — Federal AI Agent Behavioral Best Practices
 
 > **Version:** 0.1.0 | **Impact Level:** FIPS Moderate | **Scope:** Single-agent, internal enterprise
 
@@ -38,9 +38,9 @@ review_cycle: "quarterly"
 
 ---
 
-> **Disclaimer:** This playbook is informational only and is not authoritative federal policy. Each agency must tailor these rules to their specific ATO requirements, organizational policies, and risk tolerance.
+> **Disclaimer:** This playbook provides informational best practices — it is not official GSA policy or authoritative federal guidance. Each agency must tailor these recommendations to their specific ATO requirements, organizational policies, and risk tolerance. This content supports the Agentic Coding Capability Assessment being conducted at GSA-TTS.
 
-This document defines the behavioral rules that AI coding agents MUST follow when assisting federal employees with software development. Place this file (or a customized copy from `templates/AGENTS.md.template`) in the root of your repository.
+This document defines the behavioral best practices that AI coding agents SHOULD follow when assisting federal employees with software development. Place this file (or a customized copy from `templates/AGENTS.md.template`) in the root of your repository.
 
 **Key words:** "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "MAY" are used per [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
 

--- a/CONTEXT-GUIDE.md
+++ b/CONTEXT-GUIDE.md
@@ -23,13 +23,13 @@ review_cycle: "quarterly"
 3. **Load on demand** — do NOT load all documents preemptively
 4. **Security is non-negotiable** — when in doubt about a security requirement, load the relevant doc rather than guessing
 
-## Tier 1 — Always Load (~13,420 words)
+## Tier 1 — Always Load (~13,438 words)
 
 These define the behavioral contract. Load for **every task**.
 
 | Document | Words | What It Covers |
 |----------|-------|----------------|
-| `AGENTS.md` | 4,735 | Agent rules: permissions, prohibitions, data handling, identity, meta-constraints |
+| `AGENTS.md` | 4,753 | Agent rules: permissions, prohibitions, data handling, identity, meta-constraints |
 | `PLAYBOOK.md` | 1,155 | Step-by-step guide: project setup → deployment (9 phases, 11 skills) |
 | `docs/CODING_PRACTICES.md` | 6,171 | Secure coding: input validation, secrets, dependencies, architecture, TDD, SOLID |
 | `docs/CODING_STANDARDS_COMPACT.md` | 448 | **Code generation shortcut** — load INSTEAD of full CODING_PRACTICES.md for routine code tasks |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,32 @@
 # Contributing
 
-Thank you for your interest in improving the Agentic Coding Playbook. This project benefits from input by practitioners across agencies.
+Thank you for your interest in improving the Agentic Coding Playbook! This is an internal repository that benefits from input by practitioners across GSA.
 
-> **Eligibility:** We accept contributions from **federal employees** and **active federal contractors** only. If you are unsure whether you are eligible to contribute, please [open an issue](https://github.com/gsa-tts/agentic-coding-playbook/issues/new) and ask — we are happy to help.
+## Ecosystem Overview
+
+This repo is one of three in the agentic coding ecosystem:
+
+| Repo | Focus | Typical Contributions |
+|------|-------|----------------------|
+| **[Quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart)** | Environment setup | SBX fixes, troubleshooting docs |
+| **[Playbook](https://github.com/GSA-TTS/agentic-coding-playbook)** (you are here) | Standards & practices | Coding standards, skills, templates |
+| **[Patterns](https://github.com/GSA-TTS/agentic-coding-patterns)** | Community sharing | Workflows, lessons learned, examples |
+
+**Not sure where your contribution belongs?** Ask in the agentic-coding Slack channel.
+
+## Getting Help
+
+- **Questions:** Ask in the agentic-coding Slack channel
+- **Bugs/improvements:** Open a GitHub issue or submit a PR
+- **Security issues:** See [SECURITY.md](SECURITY.md) — direct fixes preferred
 
 ## How to Contribute
 
-1. **Open an issue** describing the improvement, gap, or correction
-2. **Reference the specific NIST control or framework section** that applies
-3. **Fork the repo** and make your changes on a feature branch
-4. **Submit a pull request** with a clear description of what changed and why
+The simplest approach:
+
+1. **Fix it directly** — Submit a PR (preferred for internal repos)
+2. **Not sure how?** — Open an issue to discuss first
+3. **Questions?** — Ask in the agentic-coding Slack channel
 
 ## Contribution Guidelines
 
@@ -216,8 +233,17 @@ Then run `make ci` to verify everything passes before pushing.
 
 ## Review Process
 
-All pull requests require review by at least one maintainer. Changes to security controls mapping or compliance standards require additional scrutiny.
+All pull requests require review. Changes to security standards require additional attention.
+
+## Teams
+
+- **[@GSA-TTS/agentic-coding-team](https://github.com/orgs/GSA-TTS/teams/agentic-coding-team):** Team members — review, contribute, provide feedback
+- **[@GSA-TTS/agentic-coding-admins](https://github.com/orgs/GSA-TTS/teams/agentic-coding-admins):** Repository administrators — merge, release, maintain
 
 ## Code of Conduct
 
-Be professional, constructive, and respectful. This is content that federal employees will rely on — quality and accuracy matter more than speed.
+Be professional, constructive, and respectful. Quality and accuracy matter.
+
+## Share What You Learn
+
+Discovered a useful workflow or pattern while using this playbook? Consider sharing it in the [Patterns repo](https://github.com/GSA-TTS/agentic-coding-patterns) so others can benefit.

--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -7,10 +7,10 @@
 # before making changes that span multiple documents.
 #
 # Schema version: 1.0
-# Last generated: 2026-04-14
+# Last generated: 2026-05-21
 
 schema_version: "1.0"
-generated: "2026-04-14"
+generated: "2026-05-21"
 repo: "gsa-tts/agentic-coding-playbook"
 scope: "FIPS Moderate | Single-agent | Internal enterprise"
 
@@ -33,12 +33,12 @@ frontmatter_schema:
 documents:
   # ── Tier 1: Core Guidance ────────────────────────────────────────
   - path: "AGENTS.md"
-    title: "Federal AI Agent Behavior Rules"
-    description: "Master behavioral contract defining what AI coding agents MUST, SHOULD, and MAY do in federal development environments — includes meta-constraints, engineering discipline enforcement, and verification requirements"
+    title: "Federal AI Agent Behavioral Best Practices"
+    description: "Best practices for AI coding agent behavior in federal development environments — includes behavioral standards, engineering discipline enforcement, and verification requirements"
     status: canonical
     tier: 1
     load_priority: always
-    last_updated: "2026-02-25"
+    last_updated: "2026-05-21"
     audience: all
     nist_controls_count: 26
     review_cycle: quarterly

--- a/README.md
+++ b/README.md
@@ -1,11 +1,23 @@
 # Agentic Coding Playbook
 
-Practical, tool-agnostic playbook for US federal employees building software with AI coding agents.
+Practical, tool-agnostic playbook for federal employees building software with AI coding agents.
 
 [![CI](https://github.com/gsa-tts/agentic-coding-playbook/actions/workflows/ci.yml/badge.svg)](https://github.com/gsa-tts/agentic-coding-playbook/actions/workflows/ci.yml)
 [![License: CC0-1.0](https://img.shields.io/badge/License-CC0_1.0-lightgrey.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
-> **Disclaimer:** This playbook is **informational only** and is not authoritative federal policy. Each agency must tailor these practices to their ATO requirements, organizational policies, and applicable laws. This project does not replace NIST publications, OMB memoranda, or agency-specific guidance.
+> **Note:** This playbook represents best practices. Tailor to your agency's ATO requirements and policies.
+
+## Agentic Coding Ecosystem
+
+This repository is part of a three-repo ecosystem:
+
+| Repo | Purpose | When to Use |
+|------|---------|-------------|
+| **[Quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart)** | Get running | First day setup, SBX + USAi config |
+| **[Playbook](https://github.com/GSA-TTS/agentic-coding-playbook)** (you are here) | Do it right | Repo setup, standards, best practices |
+| **[Patterns](https://github.com/GSA-TTS/agentic-coding-patterns)** | Share & learn | Community patterns, lessons learned |
+
+**Your journey:** After getting your environment running (Quickstart), use this Playbook to set up your projects with good defaults, then share what you learn in Patterns.
 
 ---
 
@@ -32,7 +44,7 @@ The agent reads your plan and sets up everything: `AGENTS.md`, coding standards,
 
 ## What This Is
 
-A set of markdown files, templates, and validation tools that tell AI coding agents **what to do** and **how to do it** when helping federal employees build software. Drop these files into any repository to get secure-by-default agent behavior across the full development lifecycle.
+A set of markdown files, templates, and validation tools that help AI coding agents follow **secure-by-default practices** when assisting federal employees with software development. Drop these files into any repository to establish consistent behavioral standards across the full development lifecycle.
 
 Designed for **FIPS Moderate** systems, **single-agent** architectures, and **internal enterprise** environments.
 
@@ -66,9 +78,9 @@ Full details: [PLAYBOOK.md](./PLAYBOOK.md)
 
 ---
 
-## Skills — Executable Compliance Procedures
+## Skills — Executable Best Practice Procedures
 
-Skills convert policy standards into step-by-step workflows that any AI coding agent can follow. The behavioral contract (`AGENTS.md`) uses the [AGENTS.md standard](https://agents.md), supported by 25+ AI coding tools.
+Skills convert best practices into step-by-step workflows that any AI coding agent can follow. The behavioral contract (`AGENTS.md`) uses the [AGENTS.md standard](https://agents.md), supported by 25+ AI coding tools.
 
 <!-- GENERATED:SKILLS_TABLE:START — do not edit, run: make generate -->
 | Skill | Purpose | Scripts? |
@@ -174,7 +186,17 @@ agentic-coding-playbook/
 
 ## Contributing
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md). This project uses [conventional commits](https://www.conventionalcommits.org/) and automated releases via [release-please](https://github.com/googleapis/release-please).
+We welcome contributions from the agentic coding community.
+
+- **Fix it directly** — Submit a PR (preferred for internal repos)
+- **Questions** — Ask in the agentic-coding Slack channel
+- **Not sure how?** — Open an issue to discuss
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for details. This project uses [conventional commits](https://www.conventionalcommits.org/) and automated releases via [release-please](https://github.com/googleapis/release-please).
+
+### Share What You Learn
+
+Discovered a useful workflow or pattern? Consider contributing it to the [Patterns repo](https://github.com/GSA-TTS/agentic-coding-patterns) so others can benefit.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,59 +2,79 @@
 
 ## Scope
 
-This repository contains **reference documentation** and a **Python validation toolchain** (`scripts/playbook_validator/`). There are no deployed services or infrastructure. Security concerns here relate to:
+This repository is part of the **Agentic Coding Capability Assessment** — an internal GSA initiative. It contains:
 
-- Incorrect or outdated security standards that could lead to insecure implementations
+- **Reference documentation** for secure agentic coding practices
+- **Python validation toolchain** (`scripts/playbook_validator/`)
+- **Skills and templates** for AI-assisted development
+
+There are no deployed services or production infrastructure. Security concerns here relate to:
+
+- Incorrect or outdated standards that could lead to insecure implementations
 - Misaligned NIST control mappings that could cause compliance gaps
-- Missing or wrong OWASP cross-references
-- Guidance that contradicts authoritative federal publications
+- Content that contradicts authoritative federal publications
 
-## Reporting a Concern
+> **Note:** This repository provides informational content and best practices. It is not authoritative GSA policy or official federal guidance.
+
+## Reporting and Fixing Security Issues
+
+This is an **internal assessment repository** with trusted contributors. The appropriate response to most issues is to fix them directly.
 
 ### For Content Accuracy Issues
 
-If you find content that is **incorrect, outdated, or could lead to insecure implementations**:
+If you find content that is incorrect, outdated, or could lead to insecure implementations:
 
-1. **Preferred:** Open a [GitHub Issue](https://github.com/gsa-tts/agentic-coding-playbook/issues/new) with the "content-accuracy" label
-2. **For sensitive issues:** Email the maintainers listed in [CODEOWNERS](./CODEOWNERS)
+1. **Submit a PR to fix it** — This is the preferred approach for internal repos
+2. **Open an issue** if you're unsure how to fix it or want to discuss first
+3. **Ask in the agentic-coding Slack channel** if you have questions or need help
 
 Please include:
-
 - Which document and section contains the issue
 - The specific content that is incorrect
 - The authoritative source that contradicts it (NIST publication, OMB memo, etc.)
 - Suggested correction
 
-### For Repository Security Issues
+### For Repository Infrastructure Issues
 
-If you find a security issue with the **repository infrastructure** (CI pipeline, GitHub Actions, etc.):
+If you find a security issue with the repository infrastructure (CI pipeline, GitHub Actions, dependencies, validation scripts):
 
-1. Use [GitHub Security Advisories](https://github.com/gsa-tts/agentic-coding-playbook/security/advisories/new) to report privately
-2. Do **not** open a public issue for infrastructure security concerns
+1. **Submit a PR to fix it** — You have access, so fix it directly when possible
+2. **Open an issue** to track the problem if you need help or it requires discussion
+3. **Contact channel admins** if you're unsure about the right approach
 
-## Response Timeline
+Since this is an internal repository, formal security advisories are not required. Use your judgment — if something seems sensitive, discuss with channel admins before posting details publicly.
 
-- **Acknowledgment:** Within 5 business days
-- **Assessment:** Within 10 business days
-- **Resolution:** Depends on severity and scope of required changes
+### For GSA Platform Issues (Outside This Repo)
 
-## Supported Versions
+For security concerns related to GSA systems or infrastructure outside the scope of this repository:
 
-| Version | Supported |
-|---------|-----------|
-| 0.1.x   | Yes       |
+- **Follow your normal GSA security reporting processes**
+- **Submit a ticket** or **email GSA security** as appropriate for your organization
+
+These repos are for the assessment — platform and infrastructure security follows standard GSA procedures.
 
 ## Framework Version Tracking
 
-This guidance tracks evolving federal standards. When a referenced framework is updated (e.g., new NIST SP revision), we will:
+This content tracks evolving federal standards. When a referenced framework is updated (e.g., new NIST SP revision), we will:
 
 1. Create an issue tracking the update
 2. Review all affected documents
 3. Update mappings and cross-references
 4. Tag a new release with updated framework versions in CHANGELOG.md
 
-## GSA Vulnerability Disclosure Policy
+## Security Best Practices
 
-For reporting vulnerabilities in GSA systems and services, please follow the GSA Vulnerability Disclosure Policy:
+When using this repository:
 
-**https://www.gsa.gov/website-information/vulnerability-disclosure-policy**
+1. **Validate all content** — Run `make validate` before using templates
+2. **Check authoritative sources** — This content references NIST/OMB/OWASP but is not a substitute
+3. **Review agent-generated code** — AI-assisted development requires human review
+4. **Follow AGENTS.md** — The behavioral contract helps prevent unsafe agent actions
+
+## Supported Versions
+
+Security updates are applied to the current `main` branch. Check the [CHANGELOG](CHANGELOG.md) for the current version.
+
+---
+
+**Last Updated:** 2026-05-21


### PR DESCRIPTION
## Summary

Improves ecosystem documentation and contribution experience across the playbook repo.

## Changes

- **README.md**: Simplify disclaimer (one note, not formal disclaimer), update ecosystem section
- **CONTRIBUTING.md**: Remove eligibility gatekeeping section, friendlier tone
- **SECURITY.md**: Update for internal repo model (direct fixes preferred)
- **AGENTS.md**: Update terminology - 'Behavior Rules' → 'Behavioral Best Practices', 'MUST follow' → 'SHOULD follow', enhanced disclaimer
- **Issue templates**: Add config.yml with correct Slack URL

## Issues Closed

Closes #35 (AGENTS.md terminology - policy vs best practices)
Closes #36 (Slack channel link to docs)

## Checklist

- [x] Documentation follows workspace conventions
- [x] Slack URL verified correct: https://gsa.enterprise.slack.com/archives/C0B44531QLE
- [x] No sensitive data included
- [x] Consistent terminology across files
- [x] make validate-docs passes