### PR TITLE
chore(ci): make pre-commit hooks opt-in

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,8 +134,70 @@ To update a mapping:
 Run once after cloning the repo:
 
 ```bash
-make setup      # Install dependencies + pre-commit hooks
+make setup      # Install dependencies only
 ```
+
+### Pre-commit Hooks (Optional)
+
+Pre-commit hooks are **optional** for this repository. They are designed for **contributors** who are actively developing this project.
+
+**If you cloned this repo for guidance only** (to reference standards for your own projects), **you do not need to install the hooks**.
+
+**If you are contributing to this repo**, you can opt-in to pre-commit hooks:
+
+```bash
+make install-hooks    # [OPTIONAL] Install pre-commit hooks
+```
+
+These hooks run automatically on `git commit` and check for:
+- YAML/JSON syntax errors
+- Trailing whitespace and end-of-file fixes
+- Secrets detection (gitleaks)
+- Python linting and formatting (ruff)
+
+**CI enforces the same checks** via `make ci`, so hooks are not required — they just provide faster feedback during local development.
+
+#### Working in SBX Containers
+
+Most users will be working **inside Docker SBX containers** per the [Quickstart guidance](https://github.com/GSA-TTS/agentic-coding-quickstart). This creates additional considerations for pre-commit hooks.
+
+**Installing the pre-commit tools in a container:**
+
+When you run `make setup` or `make install-hooks` inside an SBX container, the pre-commit tools are installed in that container's environment:
+
+```bash
+sbx exec <sandbox-name> make install-hooks
+```
+
+**Two workflows for committing changes:**
+
+**Workflow A: Edit in container, verify in container, commit on host**
+1. Edit files inside the SBX container
+2. Run `make ci` inside the container to verify all checks pass
+3. Exit the container and commit from your host machine
+4. Pre-commit hooks (if installed on host) will run again on commit
+
+This workflow is recommended because:
+- Keeps git history on the host (persistent across container restarts)
+- Verifies changes in the same environment where they'll run in CI
+- No risk of losing commits when containers are destroyed
+
+**Workflow B: Edit in container, install hooks in container, commit in container**
+1. Edit files inside the SBX container
+2. Install pre-commit hooks inside the container: `make install-hooks`
+3. Commit changes inside the container
+
+**Important:** SBX containers are ephemeral. If the container is destroyed or recreated, any hooks installed inside it will be lost. You'll need to re-run `make install-hooks` in the new container.
+
+**Recommended practice:**
+
+Before committing on your host machine, verify changes in the container first:
+
+```bash
+sbx exec <sandbox-name> make ci
+```
+
+This ensures all checks pass in the standardized SBX environment before you commit. CI will run the same checks, so catching issues early saves time.
 
 ## Before Every PR
 

--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,15 @@ install: ## Install all dependencies (use: pip or uv)
 install-uv: ## Install all dependencies using uv (faster)
 	uv pip install -e ".[dev]"
 
-.PHONY: install-hooks
-install-hooks: ## Install pre-commit hooks
-	pre-commit install
-
 .PHONY: setup
-setup: install install-hooks ## Full setup: install deps + hooks
+setup: install ## Install dependencies only (no hooks)
+	@echo "✅ Dependencies installed."
+	@echo "💡 Optional: Install pre-commit hooks with 'make install-hooks'"
+
+.PHONY: install-hooks
+install-hooks: ## [OPTIONAL] Install pre-commit hooks for contributors
+	pre-commit install
+	@echo "✅ Pre-commit hooks installed. They will run automatically on git commit."
 
 # ── Testing ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

Users clone this repo primarily for guidance, not to contribute. Auto-installing pre-commit hooks in `make setup` can interfere with their workflows:

- Conflicts with their own pre-commit configs (monorepo scenarios)
- Tool version mismatches (our ruff vs theirs)
- Unexpected hook failures when committing to their projects
- Adds cognitive load for users just reading docs

**Additional consideration:** Most contributors will be working inside Docker SBX containers per the [Quickstart guidance](https://github.com/GSA-TTS/agentic-coding-quickstart), where hook persistence is an issue.

## Solution

Make pre-commit hooks **opt-in** for contributors only:

### Changes

1. **Makefile:**
   - Remove `install-hooks` from `setup` target
   - Add standalone `install-hooks` target with `[OPTIONAL]` label
   - Add helpful message after setup: "Optional: Install pre-commit hooks with 'make install-hooks'"

2. **CONTRIBUTING.md:**
   - Add "Pre-commit Hooks (Optional)" section
   - Explain opt-in model (for contributors, not guidance readers)
   - Clarify that CI enforces same checks via `make ci`
   - **NEW:** Add "Working in SBX Containers" subsection explaining:
     - Two workflows: edit in container + commit on host (recommended), or commit in container
     - Why hooks don't persist in ephemeral containers
     - Recommended practice: `sbx exec <sandbox> make ci` before committing on host

### Verification

```bash
make ci  # All checks pass (285 tests, linting, validation, format-check, audit)
```

## Benefits

- ✅ Zero interference with user workflows (users just reading docs)
- ✅ Contributors can opt-in when ready via `make install-hooks`
- ✅ CI remains authoritative (no local-vs-CI drift)
- ✅ Clear documentation of opt-in approach + SBX context
- ✅ No breaking changes to existing workflows
- ✅ Addresses Docker SBX execution reality for most users

## Testing

- `make setup` now installs dependencies only (no hooks)
- `make install-hooks` works correctly (tested with pre-commit hooks)
- `make ci` passes all checks (lint, format-check, test, validate, audit)
- SBX workflows documented for both host and container commit scenarios

Fixes #42