### PR TITLE
fix(skills): correct CODING_PRACTICES.md path in federal-repo-setup

### DIFF
--- a/skills/federal-repo-setup/SKILL.md
+++ b/skills/federal-repo-setup/SKILL.md
@@ -329,7 +329,7 @@ Thank you for your interest in contributing to this project.
 ## Code Standards
 
 This project follows the coding practices documented in
-[docs/CODING_PRACTICES.md](docs/CODING_PRACTICES.md) (if present) or the
+[CODING_PRACTICES.md](../../docs/CODING_PRACTICES.md) (if present) or the
 language-specific conventions established in the codebase.
 
 Key expectations:


### PR DESCRIPTION
## Problem

Issue #45 reported a broken relative link in the federal-repo-setup skill documentation.

## Solution

Updated the relative path from `docs/CODING_PRACTICES.md` to `../../docs/CODING_PRACTICES.md` to properly reference the documentation file from within the `skills/federal-repo-setup/` directory.

## Verification

- [x] Verified target file exists at `docs/CODING_PRACTICES.md` in repo root
- [x] Checked for other similar broken links in the file (none found)
- [x] Pre-commit hooks passed (gitleaks, whitespace, merge conflicts, large files)

## Changes

**File:** `skills/federal-repo-setup/SKILL.md:332`

**Before:**
```markdown
[CODING_PRACTICES.md](docs/CODING_PRACTICES.md)
```

**After:**
```markdown
[CODING_PRACTICES.md](../../docs/CODING_PRACTICES.md)
```

Fixes #45