### PR TITLE
chore: add CODEOWNERS file for security-sensitive paths

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,15 @@
+# CODEOWNERS for agentic-coding-playbook
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Security-sensitive files require admin review
+/.github/workflows/         @GSA-TTS/agentic-coding-admins
+/SECURITY.md                @GSA-TTS/agentic-coding-admins
+
+# Scripts contain validation logic
+/scripts/                   @GSA-TTS/agentic-coding-admins
+
+# Skills are executable procedures
+/skills/                    @GSA-TTS/agentic-coding-team
+
+# Documentation changes
+/docs/                      @GSA-TTS/agentic-coding-team


### PR DESCRIPTION
## Summary
Adds CODEOWNERS file to enforce code review ownership for security-sensitive paths.

## Changes
- `/.github/workflows/` → admin review
- `/SECURITY.md` → admin review
- `/scripts/` → admin review
- `/skills/` → maintainer review
- `/docs/` → maintainer review

## Control Mapping
- NIST CM-3 (Configuration Change Control)
- NIST AC-6 (Least Privilege)

Closes #56