### PR TITLE
chore: add landscape RSS state file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ secrets.yml
 *.log
 *.bak
 *.backup
+
+# Runtime state files
+data/.landscape-rss-state.json


### PR DESCRIPTION
## Summary

Adds the landscape RSS state file to .gitignore.

## Change

Added `data/.landscape-rss-state.json` to .gitignore.

## Rationale

This file is a runtime state file created by the federal-landscape-update skill to track RSS feed state. It's machine-specific and should not be committed.

Co-authored-by: OpenCode Agent <agent@gsa.gov>