### PR TITLE
fix(ci): remove GITHUB_TOKEN from reusable workflow secrets

### DIFF
--- a/.github/workflows/reusable-pr-lint.yml
+++ b/.github/workflows/reusable-pr-lint.yml
@@ -7,8 +7,9 @@
 #       uses: GSA-TTS/agentic-coding-playbook/.github/workflows/reusable-pr-lint.yml@main
 #       with:
 #         validate-commits: true
-#       secrets:
-#         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#
+# Note: GITHUB_TOKEN is automatically inherited from the calling workflow.
+# Do not pass it explicitly as a secret (reserved name collision).
 
 name: Reusable PR Lint
 
@@ -30,10 +31,8 @@ on:
         required: false
         type: string
         default: '22'
-    secrets:
-      GITHUB_TOKEN:
-        description: 'GitHub token for PR access'
-        required: true
+    # Note: GITHUB_TOKEN is automatically available to reusable workflows
+    # via the permissions block - no need to pass as secret
 
 concurrency:
   group: pr-lint-${{ github.head_ref || github.ref }}
@@ -51,7 +50,7 @@ jobs:
       - name: Validate PR title
         uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155571e35 # v5.5.3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           types: |
             feat


### PR DESCRIPTION
## Summary

Fixes CI failures in quickstart and patterns repos caused by using `GITHUB_TOKEN` as a secret name in reusable workflows.

## Problem

```
Invalid workflow file: .github/workflows/pr-lint.yml#L12
error parsing called workflow
secret name \`GITHUB_TOKEN\` within \`workflow_call\` can not be used since it would collide with system reserved name
```

## Root Cause

`GITHUB_TOKEN` is a reserved secret name in GitHub Actions. When used in a `workflow_call` secrets declaration, it causes a collision with the system-provided token.

## Fix

- Remove `secrets.GITHUB_TOKEN` declaration from `workflow_call`
- Use `github.token` instead of `secrets.GITHUB_TOKEN` in action env
- The token is automatically inherited via the permissions block

## Testing

After merging, the PR Lint workflow will work in:
- agentic-coding-quickstart
- agentic-coding-patterns

## Related

Fixes CI failures introduced in PR #68 (reusable workflows)

Co-authored-by: OpenCode Agent <agent@gsa.gov>