### PR TITLE
fix(ci): correct action-semantic-pull-request SHA

### DIFF
--- a/.github/workflows/reusable-pr-lint.yml
+++ b/.github/workflows/reusable-pr-lint.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR title
-        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155571e35 # v5.5.3
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary

Corrects an incorrect SHA in the reusable-pr-lint workflow.

## Problem

```
Unable to resolve action \`amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155571e35\`, unable to find version
```

## Root Cause

The SHA was incorrectly specified. The correct SHA for v5.5.3 is:
- Wrong: `0723387faaf9b38adef4775cd42cfd5155571e35`
- Right: `0723387faaf9b38adef4775cd42cfd5155ed6017`

## Verification

```bash
git ls-remote --tags https://github.com/amannn/action-semantic-pull-request | grep v5.5.3
0723387faaf9b38adef4775cd42cfd5155ed6017  refs/tags/v5.5.3
```

Co-authored-by: OpenCode Agent <agent@gsa.gov>