### PR TITLE
fix: update doctor.py to check markdownlint-cli2 instead of pymarkdown

### DIFF
--- a/scripts/playbook_validator/doctor.py
+++ b/scripts/playbook_validator/doctor.py
@@ -292,12 +292,17 @@ def check_dependencies() -> list[dict[str, object]]:
     except ImportError:
         results.append(_result("PyYAML", False, "Run: pip install PyYAML"))
 
-    # Dev tools — optional but needed for make ci
-    for tool in ("ruff", "pymarkdown"):
-        if shutil.which(tool) is not None:
-            results.append(_result(tool, True, "installed"))
-        else:
-            results.append(_skip(tool, f"not found — install with: pip install {tool}"))
+    # ruff — Python linter/formatter
+    if shutil.which("ruff") is not None:
+        results.append(_result("ruff", True, "installed"))
+    else:
+        results.append(_skip("ruff", "not found — install with: pip install ruff"))
+
+    # markdownlint-cli2 — Markdown linter (used by pre-commit)
+    if shutil.which("markdownlint-cli2") is not None:
+        results.append(_result("markdownlint-cli2", True, "installed"))
+    else:
+        results.append(_skip("markdownlint-cli2", "not found — install with: npm install -g markdownlint-cli2"))
 
     return results
 


### PR DESCRIPTION
## Summary
Updates the doctor.py environment check to look for the correct markdown linter.

## Problem
The `check_dependencies()` function checked for `pymarkdown` which:
- Was never in `pyproject.toml`
- Is not used by this project
- The repo uses `markdownlint-cli2` per `.pre-commit-config.yaml`

## Solution
- Replace `pymarkdown` check with `markdownlint-cli2`
- Update install instructions to use `npm install -g markdownlint-cli2`
- Separate ruff and markdownlint checks for clarity

## Testing
```bash
# All 43 doctor-related tests pass
PYTHONPATH=scripts python3 -m pytest scripts/tests/ -v -k doctor

# Doctor output shows correct tool
PYTHONPATH=scripts python3 -m playbook_validator doctor
# [PASS] markdownlint-cli2
```

## Issues
Fixes #85

## Security Impact
None - development tooling check only.