### PR TITLE
test(rss): add test coverage for landscape RSS scripts

### DIFF
--- a/scripts/tests/test_check_federal_landscape_rss.py
+++ b/scripts/tests/test_check_federal_landscape_rss.py
@@ -1,0 +1,402 @@
+"""Tests for check_federal_landscape_rss.py — RSS/Atom feed monitoring.
+
+GitHub Issue: #83 - Add test coverage for landscape RSS scripts
+"""
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestLoadState:
+    """Tests for load_state function."""
+
+    def test_load_existing_state_file(self, tmp_path):
+        """Test loading an existing valid state file."""
+        from scripts.check_federal_landscape_rss import load_state
+
+        state_file = tmp_path / "state.json"
+        state_file.write_text(
+            json.dumps(
+                {
+                    "last_updated": "2026-01-01T00:00:00Z",
+                    "last_seen": {"feed1": ["id1", "id2"], "feed2": ["id3"]},
+                }
+            )
+        )
+
+        result = load_state(state_file)
+        assert result == {"feed1": ["id1", "id2"], "feed2": ["id3"]}
+
+    def test_load_missing_state_file(self, tmp_path):
+        """Test loading when state file does not exist."""
+        from scripts.check_federal_landscape_rss import load_state
+
+        state_file = tmp_path / "nonexistent.json"
+        result = load_state(state_file)
+        assert result == {}
+
+    def test_load_corrupted_json(self, tmp_path):
+        """Test loading a corrupted JSON file."""
+        from scripts.check_federal_landscape_rss import load_state
+
+        state_file = tmp_path / "corrupted.json"
+        state_file.write_text("{ invalid json }")
+
+        result = load_state(state_file)
+        assert result == {}
+
+    def test_load_state_without_last_seen_key(self, tmp_path):
+        """Test loading state file without last_seen key."""
+        from scripts.check_federal_landscape_rss import load_state
+
+        state_file = tmp_path / "state.json"
+        state_file.write_text(json.dumps({"last_updated": "2026-01-01T00:00:00Z"}))
+
+        result = load_state(state_file)
+        assert result == {}
+
+
+class TestSaveState:
+    """Tests for save_state function."""
+
+    def test_save_creates_parent_dirs(self, tmp_path):
+        """Test that save_state creates parent directories."""
+        from scripts.check_federal_landscape_rss import save_state
+
+        state_file = tmp_path / "nested" / "dirs" / "state.json"
+        last_seen = {"feed1": ["id1"]}
+
+        save_state(state_file, last_seen)
+
+        assert state_file.exists()
+        data = json.loads(state_file.read_text())
+        assert data["last_seen"] == last_seen
+
+    def test_save_overwrites_existing(self, tmp_path):
+        """Test that save_state overwrites existing file."""
+        from scripts.check_federal_landscape_rss import save_state
+
+        state_file = tmp_path / "state.json"
+        state_file.write_text(json.dumps({"old": "data"}))
+
+        new_state = {"feed1": ["new_id"]}
+        save_state(state_file, new_state)
+
+        data = json.loads(state_file.read_text())
+        assert data["last_seen"] == new_state
+        assert "old" not in data
+
+    def test_save_includes_timestamp(self, tmp_path):
+        """Test that save_state includes last_updated timestamp."""
+        from scripts.check_federal_landscape_rss import save_state
+
+        state_file = tmp_path / "state.json"
+        save_state(state_file, {})
+
+        data = json.loads(state_file.read_text())
+        assert "last_updated" in data
+        # Should be ISO format timestamp
+        assert "T" in data["last_updated"]
+
+    def test_save_handles_oserror(self, tmp_path, capsys):
+        """Test that save_state handles OSError gracefully."""
+        from scripts.check_federal_landscape_rss import save_state
+
+        # Create a directory where we expect a file (will cause OSError)
+        state_path = tmp_path / "state.json"
+        state_path.mkdir()
+
+        # Should not raise, just print warning
+        save_state(state_path, {"feed": ["id"]})
+
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err or "Could not save" in captured.err
+
+
+class TestFetchFeed:
+    """Tests for fetch_feed function."""
+
+    def test_parse_valid_feed(self):
+        """Test parsing a valid feed."""
+        from scripts.check_federal_landscape_rss import fetch_feed
+
+        mock_feed = MagicMock()
+        mock_feed.bozo = False
+        mock_feed.entries = [
+            {
+                "id": "entry1",
+                "title": "Test Entry",
+                "link": "https://example.com/1",
+                "published": "2026-01-01",
+                "summary": "Test summary",
+            }
+        ]
+
+        with patch("scripts.check_federal_landscape_rss.feedparser.parse", return_value=mock_feed):
+            result = fetch_feed("test_feed", "https://example.com/feed")
+
+        assert len(result) == 1
+        assert result[0]["id"] == "entry1"
+        assert result[0]["title"] == "Test Entry"
+
+    def test_bozo_error_returns_empty(self, capsys):
+        """Test that bozo errors with no entries return empty list."""
+        from scripts.check_federal_landscape_rss import fetch_feed
+
+        mock_feed = MagicMock()
+        mock_feed.bozo = True
+        mock_feed.bozo_exception = Exception("Parse error")
+        mock_feed.entries = []
+
+        with patch("scripts.check_federal_landscape_rss.feedparser.parse", return_value=mock_feed):
+            result = fetch_feed("test_feed", "https://example.com/feed")
+
+        assert result == []
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err
+
+    def test_extracts_entry_fields(self):
+        """Test that all expected fields are extracted from entries."""
+        from scripts.check_federal_landscape_rss import fetch_feed
+
+        mock_feed = MagicMock()
+        mock_feed.bozo = False
+        mock_feed.entries = [
+            {
+                "id": "unique-id",
+                "title": "Entry Title",
+                "link": "https://example.com/entry",
+                "published": "2026-01-15T10:00:00Z",
+                "summary": "Entry description",
+            }
+        ]
+
+        with patch("scripts.check_federal_landscape_rss.feedparser.parse", return_value=mock_feed):
+            result = fetch_feed("test_feed", "https://example.com/feed")
+
+        assert result[0]["id"] == "unique-id"
+        assert result[0]["title"] == "Entry Title"
+        assert result[0]["url"] == "https://example.com/entry"
+        assert result[0]["published"] == "2026-01-15T10:00:00Z"
+        assert result[0]["summary"] == "Entry description"
+
+    def test_truncates_long_summaries(self):
+        """Test that summaries longer than 500 chars are truncated."""
+        from scripts.check_federal_landscape_rss import fetch_feed
+
+        long_summary = "x" * 1000
+
+        mock_feed = MagicMock()
+        mock_feed.bozo = False
+        mock_feed.entries = [{"id": "1", "title": "Test", "summary": long_summary}]
+
+        with patch("scripts.check_federal_landscape_rss.feedparser.parse", return_value=mock_feed):
+            result = fetch_feed("test_feed", "https://example.com/feed")
+
+        assert len(result[0]["summary"]) == 500
+
+    def test_uses_link_when_id_missing(self):
+        """Test fallback to link when id is missing."""
+        from scripts.check_federal_landscape_rss import fetch_feed
+
+        mock_feed = MagicMock()
+        mock_feed.bozo = False
+        mock_feed.entries = [{"title": "No ID", "link": "https://example.com/fallback"}]
+
+        with patch("scripts.check_federal_landscape_rss.feedparser.parse", return_value=mock_feed):
+            result = fetch_feed("test_feed", "https://example.com/feed")
+
+        assert result[0]["id"] == "https://example.com/fallback"
+
+    def test_handles_fetch_exception(self, capsys):
+        """Test graceful handling of fetch exceptions."""
+        from scripts.check_federal_landscape_rss import fetch_feed
+
+        with patch(
+            "scripts.check_federal_landscape_rss.feedparser.parse",
+            side_effect=Exception("Network error"),
+        ):
+            result = fetch_feed("test_feed", "https://example.com/feed")
+
+        assert result == []
+        captured = capsys.readouterr()
+        assert "Error fetching" in captured.err
+
+
+class TestCheckFeeds:
+    """Tests for check_feeds function."""
+
+    def test_detects_new_entries(self, tmp_path, capsys):
+        """Test that new entries are detected correctly."""
+        from scripts.check_federal_landscape_rss import check_feeds
+
+        state_file = tmp_path / "state.json"
+        # No existing state
+
+        mock_feed = MagicMock()
+        mock_feed.bozo = False
+        mock_feed.entries = [{"id": "new-entry", "title": "New Entry", "link": "https://example.com/new"}]
+
+        with (
+            patch("scripts.check_federal_landscape_rss.feedparser.parse", return_value=mock_feed),
+            patch("scripts.check_federal_landscape_rss.FEEDS", {"test_feed": "https://example.com/feed"}),
+        ):
+            result = check_feeds(state_file)
+
+        assert len(result["new_entries"]) == 1
+        assert result["new_entries"][0]["id"] == "new-entry"
+
+    def test_ignores_seen_entries(self, tmp_path, capsys):
+        """Test that previously seen entries are not reported as new."""
+        from scripts.check_federal_landscape_rss import check_feeds
+
+        state_file = tmp_path / "state.json"
+        state_file.write_text(json.dumps({"last_seen": {"test_feed": ["already-seen"]}}))
+
+        mock_feed = MagicMock()
+        mock_feed.bozo = False
+        mock_feed.entries = [{"id": "already-seen", "title": "Old Entry", "link": "https://example.com/old"}]
+
+        with (
+            patch("scripts.check_federal_landscape_rss.feedparser.parse", return_value=mock_feed),
+            patch("scripts.check_federal_landscape_rss.FEEDS", {"test_feed": "https://example.com/feed"}),
+        ):
+            result = check_feeds(state_file)
+
+        assert len(result["new_entries"]) == 0
+
+    def test_limits_to_100_ids_per_feed(self, tmp_path, capsys):
+        """Test that only the latest 100 IDs are kept per feed."""
+        from scripts.check_federal_landscape_rss import check_feeds
+
+        state_file = tmp_path / "state.json"
+
+        # Create 150 entries
+        mock_feed = MagicMock()
+        mock_feed.bozo = False
+        mock_feed.entries = [
+            {"id": f"entry-{i}", "title": f"Entry {i}", "link": f"https://example.com/{i}"} for i in range(150)
+        ]
+
+        with (
+            patch("scripts.check_federal_landscape_rss.feedparser.parse", return_value=mock_feed),
+            patch("scripts.check_federal_landscape_rss.FEEDS", {"test_feed": "https://example.com/feed"}),
+        ):
+            check_feeds(state_file)
+
+        # Verify state file only has 100 IDs
+        saved_state = json.loads(state_file.read_text())
+        assert len(saved_state["last_seen"]["test_feed"]) == 100
+
+    def test_handles_empty_feeds(self, tmp_path, capsys):
+        """Test handling of feeds with no entries."""
+        from scripts.check_federal_landscape_rss import check_feeds
+
+        state_file = tmp_path / "state.json"
+
+        mock_feed = MagicMock()
+        mock_feed.bozo = False
+        mock_feed.entries = []
+
+        with (
+            patch("scripts.check_federal_landscape_rss.feedparser.parse", return_value=mock_feed),
+            patch("scripts.check_federal_landscape_rss.FEEDS", {"test_feed": "https://example.com/feed"}),
+        ):
+            result = check_feeds(state_file)
+
+        assert result["new_entries"] == []
+        assert result["feeds_checked"] == 1
+
+
+class TestMain:
+    """Tests for main CLI function."""
+
+    def test_exit_code_0_when_new_entries(self, tmp_path, monkeypatch, capsys):
+        """Test exit code 0 when new entries are found."""
+        from scripts import check_federal_landscape_rss
+
+        state_file = tmp_path / "state.json"
+        monkeypatch.setattr(sys, "argv", ["prog", "--state-file", str(state_file)])
+
+        mock_feed = MagicMock()
+        mock_feed.bozo = False
+        mock_feed.entries = [{"id": "new", "title": "New", "link": "https://example.com"}]
+
+        with (
+            patch("scripts.check_federal_landscape_rss.feedparser.parse", return_value=mock_feed),
+            patch("scripts.check_federal_landscape_rss.FEEDS", {"test": "https://example.com/feed"}),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            check_federal_landscape_rss.main()
+
+        assert exc_info.value.code == 0
+
+    def test_exit_code_1_when_no_new_entries(self, tmp_path, monkeypatch, capsys):
+        """Test exit code 1 when no new entries are found."""
+        from scripts import check_federal_landscape_rss
+
+        state_file = tmp_path / "state.json"
+        state_file.write_text(json.dumps({"last_seen": {"test": ["existing"]}}))
+        monkeypatch.setattr(sys, "argv", ["prog", "--state-file", str(state_file)])
+
+        mock_feed = MagicMock()
+        mock_feed.bozo = False
+        mock_feed.entries = [{"id": "existing", "title": "Old", "link": "https://example.com"}]
+
+        with (
+            patch("scripts.check_federal_landscape_rss.feedparser.parse", return_value=mock_feed),
+            patch("scripts.check_federal_landscape_rss.FEEDS", {"test": "https://example.com/feed"}),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            check_federal_landscape_rss.main()
+
+        assert exc_info.value.code == 1
+
+    def test_output_json_mode_suppresses_stderr(self, tmp_path, monkeypatch, capsys):
+        """Test that --output-json suppresses stderr messages."""
+        from scripts import check_federal_landscape_rss
+
+        state_file = tmp_path / "state.json"
+        monkeypatch.setattr(sys, "argv", ["prog", "--state-file", str(state_file), "--output-json"])
+
+        mock_feed = MagicMock()
+        mock_feed.bozo = False
+        mock_feed.entries = [{"id": "new", "title": "New", "link": "https://example.com"}]
+
+        with (
+            patch("scripts.check_federal_landscape_rss.feedparser.parse", return_value=mock_feed),
+            patch("scripts.check_federal_landscape_rss.FEEDS", {"test": "https://example.com/feed"}),
+            pytest.raises(SystemExit),
+        ):
+            check_federal_landscape_rss.main()
+
+        captured = capsys.readouterr()
+        # Stderr should be empty in JSON mode
+        assert captured.err == ""
+        # Stdout should be valid JSON
+        output = json.loads(captured.out)
+        assert "new_entries" in output
+
+    def test_cli_custom_state_file(self, tmp_path, monkeypatch, capsys):
+        """Test that --state-file argument is respected."""
+        from scripts import check_federal_landscape_rss
+
+        custom_state = tmp_path / "custom" / "path" / "state.json"
+        monkeypatch.setattr(sys, "argv", ["prog", "--state-file", str(custom_state)])
+
+        mock_feed = MagicMock()
+        mock_feed.bozo = False
+        mock_feed.entries = [{"id": "new", "title": "New", "link": "https://example.com"}]
+
+        with (
+            patch("scripts.check_federal_landscape_rss.feedparser.parse", return_value=mock_feed),
+            patch("scripts.check_federal_landscape_rss.FEEDS", {"test": "https://example.com/feed"}),
+            pytest.raises(SystemExit),
+        ):
+            check_federal_landscape_rss.main()
+
+        # State file should be created at custom path
+        assert custom_state.exists()

--- a/scripts/tests/test_check_federal_landscape_rss.py
+++ b/scripts/tests/test_check_federal_landscape_rss.py
@@ -113,7 +113,8 @@ class TestSaveState:
         save_state(state_path, {"feed": ["id"]})
 
         captured = capsys.readouterr()
-        assert "Warning" in captured.err or "Could not save" in captured.err
+        assert "Warning" in captured.err
+        assert "Could not save" in captured.err
 
 
 class TestFetchFeed:
@@ -157,6 +158,8 @@ class TestFetchFeed:
         assert result == []
         captured = capsys.readouterr()
         assert "Warning" in captured.err
+        assert "test_feed" in captured.err  # Should include feed name
+        assert "Parse error" in captured.err  # Should include exception message
 
     def test_extracts_entry_fields(self):
         """Test that all expected fields are extracted from entries."""
@@ -246,8 +249,18 @@ class TestCheckFeeds:
         ):
             result = check_feeds(state_file)
 
+        # Verify complete result structure
+        assert "check_date" in result
+        assert "T" in result["check_date"]  # ISO format
+        assert result["feeds_checked"] == 1
         assert len(result["new_entries"]) == 1
-        assert result["new_entries"][0]["id"] == "new-entry"
+
+        # Verify complete entry structure
+        entry = result["new_entries"][0]
+        assert entry["id"] == "new-entry"
+        assert entry["title"] == "New Entry"
+        assert entry["feed"] == "test_feed"
+        assert "url" in entry
 
     def test_ignores_seen_entries(self, tmp_path, capsys):
         """Test that previously seen entries are not reported as new."""
@@ -400,3 +413,77 @@ class TestMain:
 
         # State file should be created at custom path
         assert custom_state.exists()
+
+    def test_uses_updated_when_published_missing(self):
+        """Test fallback to 'updated' field when 'published' is missing."""
+        from scripts.check_federal_landscape_rss import fetch_feed
+
+        mock_feed = MagicMock()
+        mock_feed.bozo = False
+        mock_feed.entries = [
+            {
+                "id": "entry1",
+                "title": "Test Entry",
+                "link": "https://example.com/1",
+                "updated": "2026-01-15T10:00:00Z",  # No 'published', has 'updated'
+                "summary": "Test summary",
+            }
+        ]
+
+        with patch("scripts.check_federal_landscape_rss.feedparser.parse", return_value=mock_feed):
+            result = fetch_feed("test_feed", "https://example.com/feed")
+
+        assert result[0]["published"] == "2026-01-15T10:00:00Z"
+
+    def test_uses_description_when_summary_missing(self):
+        """Test fallback to 'description' field when 'summary' is missing."""
+        from scripts.check_federal_landscape_rss import fetch_feed
+
+        mock_feed = MagicMock()
+        mock_feed.bozo = False
+        mock_feed.entries = [
+            {
+                "id": "entry1",
+                "title": "Test Entry",
+                "link": "https://example.com/1",
+                "description": "Entry description",  # No 'summary', has 'description'
+            }
+        ]
+
+        with patch("scripts.check_federal_landscape_rss.feedparser.parse", return_value=mock_feed):
+            result = fetch_feed("test_feed", "https://example.com/feed")
+
+        assert result[0]["summary"] == "Entry description"
+
+    def test_multiple_feeds(self, tmp_path, capsys):
+        """Test checking multiple feeds at once."""
+        from scripts.check_federal_landscape_rss import check_feeds
+
+        state_file = tmp_path / "state.json"
+
+        mock_feed1 = MagicMock()
+        mock_feed1.bozo = False
+        mock_feed1.entries = [{"id": "feed1-entry", "title": "Feed 1", "link": "https://example.com/1"}]
+
+        mock_feed2 = MagicMock()
+        mock_feed2.bozo = False
+        mock_feed2.entries = [{"id": "feed2-entry", "title": "Feed 2", "link": "https://example.com/2"}]
+
+        def mock_parse(url):
+            if "feed1" in url:
+                return mock_feed1
+            return mock_feed2
+
+        with (
+            patch("scripts.check_federal_landscape_rss.feedparser.parse", side_effect=mock_parse),
+            patch(
+                "scripts.check_federal_landscape_rss.FEEDS",
+                {"feed1": "https://example.com/feed1", "feed2": "https://example.com/feed2"},
+            ),
+        ):
+            result = check_feeds(state_file)
+
+        assert result["feeds_checked"] == 2
+        assert len(result["new_entries"]) == 2
+        feed_names = {e["feed"] for e in result["new_entries"]}
+        assert feed_names == {"feed1", "feed2"}

--- a/scripts/tests/test_compare_landscape_versions.py
+++ b/scripts/tests/test_compare_landscape_versions.py
@@ -73,6 +73,18 @@ class TestExtractStatus:
         assert extract_status("Document has been revoked") == "revoked"
         assert extract_status("REVOKED effective immediately") == "revoked"
 
+    def test_rescinded_keyword(self):
+        """Test extraction of rescinded status."""
+        from scripts.compare_landscape_versions import extract_status
+
+        assert extract_status("This EO has been rescinded") == "rescinded"
+
+    def test_preliminary_keyword(self):
+        """Test extraction of preliminary status (maps to draft)."""
+        from scripts.compare_landscape_versions import extract_status
+
+        assert extract_status("Preliminary version for review") == "draft"
+
     def test_superseded_keyword(self):
         """Test extraction of superseded status."""
         from scripts.compare_landscape_versions import extract_status
@@ -97,6 +109,11 @@ class TestNormalizeTitle:
         result = normalize_title("NIST SP 800-218 v1.0")
         assert "1.0" not in result
         assert "v" not in result.split()
+        # Verify title content is preserved
+        assert "nist" in result
+        assert "sp" in result
+        assert "800" in result
+        assert "218" in result
 
     def test_removes_punctuation(self):
         """Test removal of punctuation."""
@@ -106,6 +123,11 @@ class TestNormalizeTitle:
         assert "(" not in result
         assert ")" not in result
         assert "!" not in result
+        # Verify content is preserved
+        assert "ai" in result
+        assert "artificial" in result
+        assert "intelligence" in result
+        assert "framework" in result
 
     def test_lowercases(self):
         """Test that result is lowercased."""
@@ -113,6 +135,7 @@ class TestNormalizeTitle:
 
         result = normalize_title("NIST Artificial Intelligence")
         assert result == result.lower()
+        assert "nist" in result
 
 
 class TestSimilarityScore:

--- a/scripts/tests/test_compare_landscape_versions.py
+++ b/scripts/tests/test_compare_landscape_versions.py
@@ -1,0 +1,389 @@
+"""Tests for compare_landscape_versions.py — Version change detection.
+
+GitHub Issue: #83 - Add test coverage for landscape RSS scripts
+"""
+
+import json
+import sys
+from io import StringIO
+
+import pytest
+import yaml
+
+
+class TestExtractVersion:
+    """Tests for extract_version function."""
+
+    def test_v1_0_format(self):
+        """Test extraction of v1.0 format versions."""
+        from scripts.compare_landscape_versions import extract_version
+
+        assert extract_version("NIST SP 800-218 v1.0") == "1.0"
+        assert extract_version("AI RMF v1.1.0") == "1.1.0"
+
+    def test_version_2_0_format(self):
+        """Test extraction of 'version X.Y' format."""
+        from scripts.compare_landscape_versions import extract_version
+
+        assert extract_version("Framework Version 2.0 Released") == "2.0"
+        assert extract_version("version 3.5.1 final") == "3.5.1"
+
+    def test_rev_format(self):
+        """Test extraction of 'rev X' format."""
+        from scripts.compare_landscape_versions import extract_version
+
+        assert extract_version("SP 800-53 Rev. 5") == "5"
+        assert extract_version("Document rev 3") == "3"
+
+    def test_no_version_returns_none(self):
+        """Test that no version pattern returns None."""
+        from scripts.compare_landscape_versions import extract_version
+
+        assert extract_version("No version here") is None
+        assert extract_version("") is None
+
+
+class TestExtractStatus:
+    """Tests for extract_status function."""
+
+    def test_draft_keyword(self):
+        """Test extraction of draft status."""
+        from scripts.compare_landscape_versions import extract_status
+
+        assert extract_status("Initial Public Draft Released") == "draft"
+        assert extract_status("This is a DRAFT document") == "draft"
+
+    def test_final_keyword(self):
+        """Test extraction of final status."""
+        from scripts.compare_landscape_versions import extract_status
+
+        assert extract_status("Final Publication Released") == "final"
+        assert extract_status("FINAL version available") == "final"
+
+    def test_ipd_maps_to_draft(self):
+        """Test that IPD maps to draft status."""
+        from scripts.compare_landscape_versions import extract_status
+
+        assert extract_status("IPD released for comment") == "draft"
+
+    def test_revoked_keyword(self):
+        """Test extraction of revoked status."""
+        from scripts.compare_landscape_versions import extract_status
+
+        assert extract_status("Document has been revoked") == "revoked"
+        assert extract_status("REVOKED effective immediately") == "revoked"
+
+    def test_superseded_keyword(self):
+        """Test extraction of superseded status."""
+        from scripts.compare_landscape_versions import extract_status
+
+        assert extract_status("This document is superseded by SP 800-218A") == "superseded"
+
+    def test_no_status_returns_none(self):
+        """Test that no status keyword returns None."""
+        from scripts.compare_landscape_versions import extract_status
+
+        assert extract_status("No status here") is None
+        assert extract_status("") is None
+
+
+class TestNormalizeTitle:
+    """Tests for normalize_title function."""
+
+    def test_removes_version_numbers(self):
+        """Test removal of version numbers."""
+        from scripts.compare_landscape_versions import normalize_title
+
+        result = normalize_title("NIST SP 800-218 v1.0")
+        assert "1.0" not in result
+        assert "v" not in result.split()
+
+    def test_removes_punctuation(self):
+        """Test removal of punctuation."""
+        from scripts.compare_landscape_versions import normalize_title
+
+        result = normalize_title("AI (Artificial Intelligence) Framework!")
+        assert "(" not in result
+        assert ")" not in result
+        assert "!" not in result
+
+    def test_lowercases(self):
+        """Test that result is lowercased."""
+        from scripts.compare_landscape_versions import normalize_title
+
+        result = normalize_title("NIST Artificial Intelligence")
+        assert result == result.lower()
+
+
+class TestSimilarityScore:
+    """Tests for similarity_score function."""
+
+    def test_identical_strings(self):
+        """Test identical strings have score 1.0."""
+        from scripts.compare_landscape_versions import similarity_score
+
+        assert similarity_score("hello world", "hello world") == 1.0
+
+    def test_no_overlap(self):
+        """Test strings with no overlap have score 0.0."""
+        from scripts.compare_landscape_versions import similarity_score
+
+        assert similarity_score("hello world", "foo bar") == 0.0
+
+    def test_partial_overlap(self):
+        """Test strings with partial overlap."""
+        from scripts.compare_landscape_versions import similarity_score
+
+        # "hello" is common, "world" and "there" are different
+        # intersection = {hello}, union = {hello, world, there}
+        result = similarity_score("hello world", "hello there")
+        assert 0.0 < result < 1.0
+        assert result == pytest.approx(1 / 3, rel=0.01)
+
+    def test_empty_strings(self):
+        """Test empty strings return 0.0."""
+        from scripts.compare_landscape_versions import similarity_score
+
+        assert similarity_score("", "") == 0.0
+        assert similarity_score("hello", "") == 0.0
+
+
+class TestFindEntryInLandscape:
+    """Tests for find_entry_in_landscape function."""
+
+    def test_exact_match(self):
+        """Test finding an entry with exact title match."""
+        from scripts.compare_landscape_versions import find_entry_in_landscape
+
+        landscape = {"entries": [{"id": "1", "title": "NIST AI Risk Management Framework"}]}
+        rss_entry = {"title": "NIST AI Risk Management Framework"}
+
+        result = find_entry_in_landscape(rss_entry, landscape)
+        assert result is not None
+        assert result["id"] == "1"
+
+    def test_similar_match_above_threshold(self):
+        """Test finding an entry with similar title above threshold."""
+        from scripts.compare_landscape_versions import find_entry_in_landscape
+
+        landscape = {"entries": [{"id": "1", "title": "NIST Artificial Intelligence Risk Management Framework v1.0"}]}
+        rss_entry = {"title": "NIST Artificial Intelligence Risk Management Framework v2.0"}
+
+        result = find_entry_in_landscape(rss_entry, landscape)
+        assert result is not None
+
+    def test_no_match_below_threshold(self):
+        """Test no match when similarity is below threshold."""
+        from scripts.compare_landscape_versions import find_entry_in_landscape
+
+        landscape = {"entries": [{"id": "1", "title": "Completely Different Document"}]}
+        rss_entry = {"title": "NIST AI Framework"}
+
+        result = find_entry_in_landscape(rss_entry, landscape)
+        assert result is None
+
+
+class TestCompareVersions:
+    """Tests for compare_versions function."""
+
+    def test_detects_version_change(self):
+        """Test detection of version changes."""
+        from scripts.compare_landscape_versions import compare_versions
+
+        landscape = {
+            "entries": [
+                {
+                    "id": "nist-ai-rmf",
+                    "title": "NIST AI Risk Management Framework",
+                    "version": "1.0",
+                    "status": "final",
+                }
+            ]
+        }
+        rss_data = {
+            "check_date": "2026-01-15T00:00:00Z",
+            "new_entries": [
+                {
+                    "title": "NIST AI Risk Management Framework v2.0",
+                    "summary": "Version 2.0 now available",
+                    "url": "https://example.com",
+                    "feed": "nist_csrc",
+                }
+            ],
+        }
+
+        result = compare_versions(landscape, rss_data)
+        assert result["changes_detected"] == 1
+        assert result["changes"][0]["type"] == "update"
+        assert result["changes"][0]["change"]["new_version"] == "2.0"
+
+    def test_detects_status_change(self):
+        """Test detection of status changes (returns as new_publication when no existing match)."""
+        from scripts.compare_landscape_versions import compare_versions
+
+        # Note: The function only detects status changes when it finds a matching
+        # entry in the landscape. If titles differ too much, it's a new_publication.
+        landscape = {
+            "entries": [
+                {
+                    "id": "doc-1",
+                    "title": "Test Document",
+                    "version": "1.0",
+                    "status": "draft",
+                }
+            ]
+        }
+        rss_data = {
+            "check_date": "2026-01-15T00:00:00Z",
+            "new_entries": [
+                {
+                    "title": "Test Document",
+                    "summary": "Final version now published",
+                    "url": "https://example.com",
+                    "published": "2026-01-15",
+                    "feed": "test_feed",
+                }
+            ],
+        }
+
+        result = compare_versions(landscape, rss_data)
+        assert result["changes_detected"] == 1
+        assert result["changes"][0]["type"] == "update"
+        assert result["changes"][0]["change"]["new_status"] == "final"
+
+    def test_detects_new_publication(self):
+        """Test detection of new publications not in registry."""
+        from scripts.compare_landscape_versions import compare_versions
+
+        landscape = {"entries": []}
+        rss_data = {
+            "check_date": "2026-01-15T00:00:00Z",
+            "new_entries": [
+                {
+                    "title": "Brand New Document v1.0",
+                    "summary": "A completely new publication",
+                    "url": "https://example.com/new",
+                    "published": "2026-01-15",
+                    "feed": "test_feed",
+                }
+            ],
+        }
+
+        result = compare_versions(landscape, rss_data)
+        assert result["changes_detected"] == 1
+        assert result["changes"][0]["type"] == "new_publication"
+        assert result["changes"][0]["suggested_version"] == "1.0"
+
+    def test_no_changes(self):
+        """Test when there are no changes to detect."""
+        from scripts.compare_landscape_versions import compare_versions
+
+        landscape = {"entries": []}
+        rss_data = {"check_date": "2026-01-15T00:00:00Z", "new_entries": []}
+
+        result = compare_versions(landscape, rss_data)
+        assert result["changes_detected"] == 0
+        assert result["changes"] == []
+
+
+class TestLoadLandscape:
+    """Tests for load_landscape function."""
+
+    def test_load_valid_landscape(self, tmp_path):
+        """Test loading a valid landscape YAML file."""
+        from scripts.compare_landscape_versions import load_landscape
+
+        landscape_file = tmp_path / "landscape.yaml"
+        landscape_file.write_text(yaml.dump({"entries": [{"id": "1", "title": "Test"}]}))
+
+        result = load_landscape(landscape_file)
+        assert result["entries"][0]["id"] == "1"
+
+
+class TestLoadRssData:
+    """Tests for load_rss_data function."""
+
+    def test_load_from_file(self, tmp_path):
+        """Test loading RSS data from a file."""
+        from scripts.compare_landscape_versions import load_rss_data
+
+        rss_file = tmp_path / "rss.json"
+        rss_file.write_text(json.dumps({"new_entries": [], "check_date": "2026-01-15"}))
+
+        result = load_rss_data(rss_file)
+        assert "new_entries" in result
+
+    def test_load_from_stdin(self, monkeypatch):
+        """Test loading RSS data from stdin."""
+        from scripts.compare_landscape_versions import load_rss_data
+
+        stdin_data = json.dumps({"new_entries": [{"title": "Test"}], "check_date": "2026-01-15"})
+        monkeypatch.setattr(sys, "stdin", StringIO(stdin_data))
+
+        result = load_rss_data(None)
+        assert len(result["new_entries"]) == 1
+
+
+class TestMain:
+    """Tests for main CLI function."""
+
+    def test_exit_code_0_when_changes(self, tmp_path, monkeypatch):
+        """Test exit code 0 when changes are detected."""
+        from scripts import compare_landscape_versions
+
+        # Create landscape file
+        landscape_file = tmp_path / "landscape.yaml"
+        landscape_file.write_text(yaml.dump({"entries": []}))
+
+        # Create RSS data file
+        rss_file = tmp_path / "rss.json"
+        rss_file.write_text(
+            json.dumps(
+                {
+                    "check_date": "2026-01-15",
+                    "new_entries": [
+                        {
+                            "title": "New Doc",
+                            "summary": "",
+                            "url": "https://example.com",
+                            "published": "2026-01-15",
+                            "feed": "test",
+                        }
+                    ],
+                }
+            )
+        )
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["prog", "--landscape-file", str(landscape_file), "--rss-data", str(rss_file)],
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            compare_landscape_versions.main()
+
+        assert exc_info.value.code == 0
+
+    def test_exit_code_1_when_no_changes(self, tmp_path, monkeypatch):
+        """Test exit code 1 when no changes are detected."""
+        from scripts import compare_landscape_versions
+
+        # Create landscape file
+        landscape_file = tmp_path / "landscape.yaml"
+        landscape_file.write_text(yaml.dump({"entries": []}))
+
+        # Create RSS data file with no entries
+        rss_file = tmp_path / "rss.json"
+        rss_file.write_text(json.dumps({"check_date": "2026-01-15", "new_entries": []}))
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["prog", "--landscape-file", str(landscape_file), "--rss-data", str(rss_file)],
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            compare_landscape_versions.main()
+
+        assert exc_info.value.code == 1


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for the landscape RSS monitoring scripts (GitHub issue #83).

## Changes

### New Test Files

- **`test_check_federal_landscape_rss.py`** — 22 tests
  - `load_state`: file loading, missing file, corrupted JSON, missing keys
  - `save_state`: directory creation, overwrite, timestamps, OSError handling
  - `fetch_feed`: parsing, bozo errors, field extraction, truncation, exceptions
  - `check_feeds`: new entry detection, seen filtering, ID limits, empty feeds
  - `main` CLI: exit codes, JSON mode, custom state file

- **`test_compare_landscape_versions.py`** — 29 tests
  - `extract_version`: v1.0, version X.Y, rev X formats
  - `extract_status`: draft, final, IPD, revoked, superseded keywords
  - `normalize_title`: version removal, punctuation, lowercasing
  - `similarity_score`: identical, no overlap, partial overlap, empty strings
  - `find_entry_in_landscape`: exact match, similar match, no match
  - `compare_versions`: version changes, status changes, new publications
  - `load_landscape`: valid YAML loading
  - `load_rss_data`: file and stdin loading
  - `main` CLI: exit codes

## Test Results

```
336 passed in 2.46s
```

(Previously 285 tests, +51 new tests)

## Coverage Notes

- All tests use mocked `feedparser` to avoid network calls
- Tests use `tmp_path` fixtures for isolated file system operations
- State persistence and CLI argument parsing fully tested
- `landscape_monitor.py` is the third RSS script — it shares patterns with the tested scripts and was deferred to keep PR size manageable

Fixes: #83 (2 of 3 RSS scripts — `landscape_monitor.py` can be a follow-up)