### PR TITLE
fix(ci): upgrade pip before pip-audit to avoid PYSEC-2026-196

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
 
       - name: SCA vulnerability scan
         run: |
+          # Upgrade pip first to avoid self-referential vulnerability (PYSEC-2026-196)
+          pip install --upgrade pip
           pip install pip-audit
           # Audit the installed environment but skip pip/setuptools (CI tooling).
           # The --skip-editable flag ignores the local playbook-validator package.


### PR DESCRIPTION
## Summary

Fixes CI failure caused by pip 26.1.1 having a known vulnerability (PYSEC-2026-196).

## Problem

The GitHub Actions runner ships with pip 26.1.1, which pip-audit correctly flags as vulnerable. This causes the SCA vulnerability scan to fail.

## Solution

Upgrade pip before running pip-audit:
```bash
pip install --upgrade pip
pip install pip-audit
pip-audit --skip-editable
```

## Verification

CI should pass after this change.