### PR TITLE
docs: codify PR-title Action commit-validation standard + squash-merge preference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -669,7 +669,7 @@ For detailed repo-specific reference (canonical paths, validation package, conte
 ### Quick Reference
 
 ```bash
-# Validation (Python package — 341 tests)
+# Validation (Python package — 368 tests)
 PYTHONPATH=scripts python3 -m playbook_validator validate-docs
 PYTHONPATH=scripts python3 -m playbook_validator validate-skills
 PYTHONPATH=scripts python3 -m playbook_validator validate-landscape

--- a/CONTEXT-GUIDE.md
+++ b/CONTEXT-GUIDE.md
@@ -23,7 +23,7 @@ review_cycle: "quarterly"
 3. **Load on demand** — do NOT load all documents preemptively
 4. **Security is non-negotiable** — when in doubt about a security requirement, load the relevant doc rather than guessing
 
-## Tier 1 — Always Load (~14,029 words)
+## Tier 1 — Always Load (~14,110 words)
 
 These define the behavioral contract. Load for **every task**.
 
@@ -31,7 +31,7 @@ These define the behavioral contract. Load for **every task**.
 |----------|-------|----------------|
 | `AGENTS.md` | 4,771 | Agent rules: permissions, prohibitions, data handling, identity, meta-constraints |
 | `PLAYBOOK.md` | 1,155 | Step-by-step guide: project setup → deployment (9 phases, 11 skills) |
-| `docs/CODING_PRACTICES.md` | 6,557 | Secure coding: input validation, secrets, dependencies, architecture, TDD, SOLID |
+| `docs/CODING_PRACTICES.md` | 6,638 | Secure coding: input validation, secrets, dependencies, architecture, TDD, SOLID |
 | `docs/CODING_STANDARDS_COMPACT.md` | 450 | **Code generation shortcut** — load INSTEAD of full CODING_PRACTICES.md for routine code tasks |
 | `docs/AGENT-INSTRUCTIONS.md` | 1,096 | Repo-specific tooling reference: canonical paths, validation commands, context budgets |
 

--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -7,10 +7,10 @@
 # before making changes that span multiple documents.
 #
 # Schema version: 1.0
-# Last generated: 2026-06-10
+# Last generated: 2026-06-12
 
 schema_version: "1.0"
-generated: "2026-06-10"
+generated: "2026-06-12"
 repo: "gsa-tts/agentic-coding-playbook"
 scope: "FIPS Moderate | Single-agent | Internal enterprise"
 
@@ -86,7 +86,7 @@ documents:
     status: canonical
     tier: 1
     load_priority: always
-    last_updated: "2026-06-05"
+    last_updated: "2026-06-11"
     audience: developers
     nist_controls_count: 23
     review_cycle: quarterly

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Skills convert best practices into step-by-step workflows that any AI coding age
 
 ## Developer Tools
 
-All validation and generation tools live in the `scripts/playbook_validator/` Python package (341 tests).
+All validation and generation tools live in the `scripts/playbook_validator/` Python package (368 tests).
 
 ```bash
 make help              # Show all available commands
@@ -167,7 +167,7 @@ agentic-coding-playbook/
 ├── data/
 │   └── federal-ai-landscape.yaml    # Machine-readable guidance registry
 ├── scripts/
-│   ├── playbook_validator/          # Python validation package (341 tests)
+│   ├── playbook_validator/          # Python validation package (368 tests)
 │   └── tests/                       # TDD test suite
 ├── skills/                          # 12 executable compliance procedures
 ├── templates/                       # PROJECT_PLAN.md, AGENTS.md.template

--- a/docs/AGENT-INSTRUCTIONS.md
+++ b/docs/AGENT-INSTRUCTIONS.md
@@ -16,7 +16,7 @@ Model-agnostic reference for any AI coding agent working in this repository. Rea
 ## Quick Reference
 
 ```bash
-# Validation (Python package — 341 tests)
+# Validation (Python package — 368 tests)
 PYTHONPATH=scripts python3 -m playbook_validator validate-docs
 PYTHONPATH=scripts python3 -m playbook_validator validate-skills
 PYTHONPATH=scripts python3 -m playbook_validator validate-landscape

--- a/docs/CODING_PRACTICES.md
+++ b/docs/CODING_PRACTICES.md
@@ -3,7 +3,7 @@ title: "Secure Coding Practices for AI-Assisted Federal Development"
 description: "Secure coding standards for AI-assisted development — input validation, secrets management, dependency security, architecture discipline, change safety, SOLID principles, OWASP/SSDF alignment"
 status: canonical
 tier: 1
-last_updated: "2026-06-05"
+last_updated: "2026-06-11"
 nist_controls: ["SA-8", "SA-11", "SA-12", "SA-15", "SA-17", "SI-2", "SI-4", "SI-7", "SI-10", "SI-11", "SI-15", "SC-3", "SC-13", "SC-28", "CP-10", "CA-7", "CM-2", "CM-3", "IA-2", "IA-5", "AC-3", "AU-2", "SR-3"]
 frameworks: ["NIST SP 800-53 Rev 5.2", "NIST SP 800-218A", "OWASP Top 10 LLM 2025", "OWASP Top 10 Agentic 2026", "CISA Secure by Design"]
 audience: "developers"
@@ -407,7 +407,16 @@ This section defines version control and release management requirements for fed
   - `BREAKING CHANGE:` footer or `!` suffix → Major version bump
   - `docs:`, `chore:`, `test:`, `ci:`, `build:`, `style:`, `refactor:`, `perf:` → No version bump (configurable)
 
-- MUST validate commit messages in CI (commitlint)
+- MUST validate conventional-commit format in CI. The recommended mechanism is a
+  pinned PR-title-linting GitHub Action (e.g. `amannn/action-semantic-pull-request`,
+  referenced by full commit SHA) rather than a local `commitlint` install:
+  - It requires **no local npm/commitlint dependency** (smaller supply-chain and
+    maintenance surface).
+  - **Squash-merge is the preferred merge strategy** — the validated PR title
+    becomes the squashed commit subject that release-please consumes for version
+    bumps. This also satisfies the "SHOULD require linear history" guidance below.
+  - `commitlint-cli` MAY be adopted as optional local convenience tooling, but
+    MUST NOT be required.
 - MUST create git tags for all releases (`v<version>`)
 - MUST generate GitHub releases with release notes from CHANGELOG
 - Release artifacts MUST be signed per §10.2


### PR DESCRIPTION
## Summary

Resolves #108. `docs/CODING_PRACTICES.md` §10.3 said *"MUST validate commit messages in CI (commitlint)"*, which no longer matches the actual cross-repo standard. All three agentic-coding repos enforce conventional format via the **SHA-pinned `amannn/action-semantic-pull-request` Action** (PR title), not commitlint. The redundant/unused local commitlint stacks are being removed from quickstart (#145) and patterns (#124) to drop an npm transitive-dependency tree for a check the merge gate already performs.

As the upstream canonical doc, this codifies the standard so downstream repos don't reintroduce drift.

## Changes (§10.3 Release Automation)
- Conventional-commit conformance MUST be validated in CI; the **recommended mechanism is a pinned PR-title-linting Action** (no local npm/commitlint dependency).
- **Squash-merge is the preferred merge strategy** — the validated PR title becomes the squashed commit subject release-please consumes; aligns with the existing "SHOULD require linear history" guidance.
- `commitlint-cli` MAY be adopted as optional local convenience tooling, but MUST NOT be required.
- Regenerated `INDEX.yaml` + auto-generated strings via `make generate` (frontmatter `last_updated` bump).

## Verification
- `make generate-check` → OK.
- `validate-docs` → 0 errors.

## Closes
Closes #108

Co-authored-by: OpenCode Agent <william.zujkowski@gsa.gov>