### PR TITLE
chore(deps): bump ruff from 0.15.16 to 0.15.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest==9.1.0",
-    "ruff==0.15.16",
+    "ruff==0.15.17",
     "pre-commit==4.6.0",
 ]
 


### PR DESCRIPTION
Re-applies Dependabot #116 on top of current main (the original PR conflicted after #115 (pytest 9.1.0) merged into the same `dev` deps block). Dev-dependency pin only.

Closes #116.

AI-assisted (OpenCode).