### PR TITLE
docs: add missing docs to index; correct control count to 35

### DIFF
--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -7,10 +7,10 @@
 # before making changes that span multiple documents.
 #
 # Schema version: 1.0
-# Last generated: 2026-06-17
+# Last generated: 2026-06-22
 
 schema_version: "1.0"
-generated: "2026-06-17"
+generated: "2026-06-22"
 repo: "gsa-tts/agentic-coding-playbook"
 scope: "FIPS Moderate | Single-agent | Internal enterprise"
 
@@ -102,7 +102,7 @@ documents:
 
   - path: "docs/SECURITY-CONTROLS.md"
     title: "NIST SP 800-53 Rev 5.2 Control Overlay for Agentic AI Systems"
-    description: "800-53 control overlay mapping 36 security controls across 10 families to concrete AI agent behaviors and verification methods"
+    description: "800-53 control overlay mapping 35 security controls across 10 families to concrete AI agent behaviors and verification methods"
     status: canonical
     tier: 1
     load_priority: task-context

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Canonical index of all documentation in the agentic-coding-playbook.
 | Document | Description |
 |----------|-------------|
 | [AGENTS.md](../AGENTS.md) | Agent behavioral contract — permissions, prohibitions, data handling |
+| [AGENT-INSTRUCTIONS.md](AGENT-INSTRUCTIONS.md) | Model-agnostic repo-specific reference (canonical paths, validation package, context budgets) |
 | [CODING_PRACTICES.md](CODING_PRACTICES.md) | Secure coding standards for AI-assisted development |
 | [CODING_STANDARDS_COMPACT.md](CODING_STANDARDS_COMPACT.md) | LLM-optimized compact coding standards (~500 words) |
 | [PLAYBOOK.md](../PLAYBOOK.md) | Step-by-step guide from project setup to deployment |
@@ -15,7 +16,7 @@ Canonical index of all documentation in the agentic-coding-playbook.
 
 | Document | Description |
 |----------|-------------|
-| [SECURITY-CONTROLS.md](SECURITY-CONTROLS.md) | NIST 800-53 Rev 5 control overlay (36 controls mapped) |
+| [SECURITY-CONTROLS.md](SECURITY-CONTROLS.md) | NIST 800-53 Rev 5 control overlay (35 controls mapped) |
 | [AGENT-IDENTITY.md](AGENT-IDENTITY.md) | Authentication, authorization, RBAC for AI agents |
 | [FEDERAL-AI-LANDSCAPE.md](FEDERAL-AI-LANDSCAPE.md) | Federal AI guidance catalog (39 entries) |
 
@@ -24,6 +25,8 @@ Canonical index of all documentation in the agentic-coding-playbook.
 | Document | Description |
 |----------|-------------|
 | [GETTING-STARTED.md](GETTING-STARTED.md) | Detailed repo setup walkthrough |
+| [PROMPT-INJECTION-DEFENSE.md](PROMPT-INJECTION-DEFENSE.md) | Implementation patterns for defending against prompt injection |
+| [ROADMAP.md](ROADMAP.md) | Long-term plan for the playbook as a living federal resource |
 | [TRACEABILITY.md](TRACEABILITY.md) | Bidirectional control-to-document matrix |
 
 ## Data Files

--- a/docs/SECURITY-CONTROLS.md
+++ b/docs/SECURITY-CONTROLS.md
@@ -1,6 +1,6 @@
 ---
 title: "NIST SP 800-53 Rev 5.2 Control Overlay for Agentic AI Systems"
-description: "800-53 control overlay mapping 36 security controls across 10 families to concrete AI agent behaviors and verification methods"
+description: "800-53 control overlay mapping 35 security controls across 10 families to concrete AI agent behaviors and verification methods"
 status: canonical
 tier: 1
 last_updated: "2026-06-12"
@@ -21,8 +21,7 @@ review_cycle: "quarterly"
 
 ## Quick Reference
 
-36 controls across 10 families. Key families for AI agent systems:
-
+35 controls across 10 families. Key families for AI agent systems:
 | Family | Controls | Agent-Specific Focus |
 |--------|----------|---------------------|
 | AC (Access Control) | AC-2, AC-3, AC-5, AC-6, AC-12, AC-17 | Agent identity, least privilege, session management |


### PR DESCRIPTION
Closes #120, #121.

## #120 — docs/README.md index omitted real docs
The 'canonical index' was missing three docs that exist:
- **AGENT-INSTRUCTIONS.md** (tier 1) — the repo tooling reference
- **PROMPT-INJECTION-DEFENSE.md** (tier 3)
- **ROADMAP.md** (tier 3)

Added to the appropriate tier tables.

## #121 — control count off by one
`SECURITY-CONTROLS.md` claimed '36 controls' (frontmatter description + Quick Reference prose), but both the frontmatter `nist_controls` array and the detailed control-row table count **35**. Corrected the '36' references to 35 (incl. the `docs/README.md` index line). 35 controls across 10 families (AC AU CM IA IR RA SA SC SI SR).

## Verification
```
make generate     -> INDEX.yaml regenerated
validate-docs     -> Errors: 0
generate-check    -> up to date
pytest            -> 368 passed
```

## Security Impact
None — documentation accuracy only.

AI-assisted (OpenCode).