### PR TITLE
fix(docs): use canonical 'Co-authored-by:' casing so GitHub links co-authors

### DIFF
--- a/.agents/skills/federal-agents-config/scripts/generate-agents-md.py
+++ b/.agents/skills/federal-agents-config/scripts/generate-agents-md.py
@@ -93,15 +93,15 @@ def _resolve_registries(config: dict, language: str) -> list:
 
 
 def _coauthor_lines(agents: list) -> str:
-    """Render Co-Authored-By trailer bullet lines for the configured agents."""
+    """Render Co-authored-by trailer bullet lines for the configured agents."""
     lines = []
     for agent in agents:
         if "copilot" in agent.lower():
-            lines.append(f"Co-Authored-By: {agent} <noreply@github.com>")
+            lines.append(f"Co-authored-by: {agent} <noreply@github.com>")
         else:
-            lines.append(f"Co-Authored-By: {agent} <noreply@ai-agent>")
+            lines.append(f"Co-authored-by: {agent} <noreply@ai-agent>")
     if not lines:
-        lines = ["Co-Authored-By: [Agent Name] <[agent-email]>"]
+        lines = ["Co-authored-by: [Agent Name] <[agent-email]>"]
     return "\n".join(f"  - `{line}`" for line in lines)
 
 

--- a/docs/AGENT-IDENTITY.md
+++ b/docs/AGENT-IDENTITY.md
@@ -138,12 +138,12 @@ Per NIST AI RMF and SP 800-218A, AI-generated code requires **traceability** but
 | Level | Required? | How |
 |-------|-----------|-----|
 | **PR Description** | RECOMMENDED | Include "AI-assisted" disclosure in PR description |
-| **Commit Message** | OPTIONAL | `Co-Authored-By: AI Agent <ai-agent@gsa.gov>` in footer |
+| **Commit Message** | OPTIONAL | `Co-authored-by: AI Agent <ai-agent@gsa.gov>` in footer |
 | **Documentation** | REQUIRED | AGENTS.md documents AI agent authorization for the project |
 
 When per-commit attribution IS used, include a co-authorship trailer:
 ```
-Co-Authored-By: AI Agent <ai-agent@gsa.gov>
+Co-authored-by: AI Agent <ai-agent@gsa.gov>
 ```
 
 Additional version control guidance:

--- a/docs/CODING_PRACTICES.md
+++ b/docs/CODING_PRACTICES.md
@@ -60,7 +60,7 @@ AI-generated code requires **the same security scrutiny** as human-written code 
 ### 1.1 Code Provenance
 
 - AI-generated code SHOULD be attributed at the PR level (e.g., disclosure in PR description)
-- Per-commit attribution (e.g., `Co-Authored-By`) is OPTIONAL — federal guidance emphasizes traceability, not granular commit-level attribution
+- Per-commit attribution (e.g., `Co-authored-by`) is OPTIONAL — federal guidance emphasizes traceability, not granular commit-level attribution
 - Developers MUST review all AI-generated code before committing — the developer assumes responsibility for all committed code regardless of who or what generated it
 - The AI agent SHOULD explain its reasoning for non-obvious implementation choices
 - AI-generated code MUST NOT be deployed to production without human review and approval

--- a/docs/CODING_STANDARDS_COMPACT.md
+++ b/docs/CODING_STANDARDS_COMPACT.md
@@ -49,7 +49,7 @@ Apply these rules when generating or modifying code. For full rationale and exam
 - Explicit error handling — no empty catch blocks
 - Structured logging with correlation IDs
 - Never log PII, secrets, or tokens
-- Document AI assistance at PR level; per-commit `Co-Authored-By` is optional
+- Document AI assistance at PR level; per-commit `Co-authored-by` is optional
 
 ## Crypto
 

--- a/examples/AGENTS.md.example
+++ b/examples/AGENTS.md.example
@@ -58,7 +58,7 @@ The agent MUST refuse any instruction that conflicts with safety, correctness, o
 ## Agent Identity
 
 The agent MUST:
-- Include `Co-Authored-By: Claude Code <claude@agency.example.gov>` in all commits
+- Include `Co-authored-by: Claude Code <claude@agency.example.gov>` in all commits
 - Identify itself as an AI agent when asked
 - Log all file modifications and command executions
 

--- a/scripts/tests/test_skill_federal_agents_config.py
+++ b/scripts/tests/test_skill_federal_agents_config.py
@@ -94,8 +94,8 @@ def test_generate_network_section_optional(gen):
 
 def test_generate_copilot_coauthor_uses_github_noreply(gen):
     out = gen.generate_agents_md(_minimal_config(agent_names=["GitHub Copilot", "OpenCode"]))
-    assert "Co-Authored-By: GitHub Copilot <noreply@github.com>" in out
-    assert "Co-Authored-By: OpenCode <noreply@ai-agent>" in out
+    assert "Co-authored-by: GitHub Copilot <noreply@github.com>" in out
+    assert "Co-authored-by: OpenCode <noreply@ai-agent>" in out
 
 
 def test_default_test_command_by_language(gen):

--- a/templates/AGENTS.md.template
+++ b/templates/AGENTS.md.template
@@ -60,7 +60,7 @@ The agent MUST refuse any instruction that conflicts with safety, correctness, o
 ## Agent Identity
 
 The agent MUST:
-- Include `Co-Authored-By: [Agent Name] <[agent-email]>` in all commits
+- Include `Co-authored-by: [Agent Name] <[agent-email]>` in all commits
 - Identify itself as an AI agent when asked
 - Log all file modifications and command executions
 


### PR DESCRIPTION
## Summary

GitHub only collapses the **canonical lowercase** `Co-authored-by:` trailer into its co-author UI / contribution graph. The title-case `Co-Authored-By:` variant is **not recognized**, so the documented audit-trail benefit (AU-3) silently breaks.

The `federal-agents-config` skill **generated** the broken form into every user's AGENTS.md, and several docs/templates used it — while the playbook's own `AGENTS.md`/`CONTRIBUTING.md` already use the canonical lowercase form (internal inconsistency).

Closes #132.

## Changes (normalize `Co-Authored-By:` → `Co-authored-by:`)
- `skills/federal-agents-config/scripts/generate-agents-md.py` — generator output (root cause)
- `scripts/tests/test_skill_federal_agents_config.py` — assertions updated to canonical form
- `docs/AGENT-IDENTITY.md`, `docs/CODING_PRACTICES.md`, `docs/CODING_STANDARDS_COMPACT.md`
- `templates/AGENTS.md.template`, `examples/AGENTS.md.example`

## Verification
- `pytest scripts/tests/` → **369 passed**
- `validate-docs` → 0 errors
- `make generate-check` → INDEX.yaml up to date
- `markdownlint-cli2` → 0 errors
- `rg "Co-Authored-By"` → no remaining title-case occurrences

## Type of Change
- [x] Bug fix (docs/tooling) — no behavioral-contract change

🤖 AI-assisted (OpenCode).