### PR TITLE
feat(landscape): add agency_report category + source-code/IP/provenance entries

### DIFF
--- a/CONTEXT-GUIDE.md
+++ b/CONTEXT-GUIDE.md
@@ -23,17 +23,17 @@ review_cycle: "quarterly"
 3. **Load on demand** — do NOT load all documents preemptively
 4. **Security is non-negotiable** — when in doubt about a security requirement, load the relevant doc rather than guessing
 
-## Tier 1 — Always Load (~15,345 words)
+## Tier 1 — Always Load (~15,415 words)
 
 These define the behavioral contract. Load for **every task**.
 
 | Document | Words | What It Covers |
 |----------|-------|----------------|
-| `AGENTS.md` | 5,758 | Agent rules: permissions, prohibitions, data handling, identity, meta-constraints |
+| `AGENTS.md` | 5,759 | Agent rules: permissions, prohibitions, data handling, identity, meta-constraints |
 | `PLAYBOOK.md` | 1,155 | Step-by-step guide: project setup → deployment (9 phases, 12 skills) |
 | `docs/CODING_PRACTICES.md` | 6,886 | Secure coding: input validation, secrets, dependencies, architecture, TDD, SOLID |
 | `docs/CODING_STANDARDS_COMPACT.md` | 450 | **Code generation shortcut** — load INSTEAD of full CODING_PRACTICES.md for routine code tasks |
-| `docs/AGENT-INSTRUCTIONS.md` | 1,096 | Repo-specific tooling reference: canonical paths, validation commands, context budgets |
+| `docs/AGENT-INSTRUCTIONS.md` | 1,165 | Repo-specific tooling reference: canonical paths, validation commands, context budgets |
 
 ## Tier 2 — Load When Task Matches (~12,840 words)
 

--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -7,10 +7,10 @@
 # before making changes that span multiple documents.
 #
 # Schema version: 1.0
-# Last generated: 2026-06-26
+# Last generated: 2026-06-30
 
 schema_version: "1.0"
-generated: "2026-06-26"
+generated: "2026-06-30"
 repo: "gsa-tts/agentic-coding-playbook"
 scope: "FIPS Moderate | Single-agent | Internal enterprise"
 
@@ -118,7 +118,7 @@ documents:
     status: canonical
     tier: 2
     load_priority: on-demand
-    last_updated: "2026-06-01"
+    last_updated: "2026-06-29"
     audience: [developers, isso, managers, agents]
 
   - path: "docs/GETTING-STARTED.md"

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Skills convert best practices into step-by-step workflows that any AI coding age
 
 ## Developer Tools
 
-All validation and generation tools live in the `scripts/playbook_validator/` Python package (369 tests).
+All validation and generation tools live in the `scripts/playbook_validator/` Python package (370 tests).
 
 ```bash
 make help              # Show all available commands
@@ -144,7 +144,7 @@ Every practice maps to one or more authoritative sources:
 | [OMB M-25-21](https://www.whitehouse.gov/wp-content/uploads/2025/02/M-25-21-Accelerating-Federal-Use-of-AI-through-Innovation-Governance-and-Public-Trust.pdf) | Apr 2025 | Federal AI governance |
 | [CISA Secure by Design](https://www.cisa.gov/securebydesign) | 2025 | Secure-by-default principles |
 
-Full catalog of 39 federal AI guidance documents: [docs/FEDERAL-AI-LANDSCAPE.md](./docs/FEDERAL-AI-LANDSCAPE.md)
+Full catalog of 42 federal AI guidance documents: [docs/FEDERAL-AI-LANDSCAPE.md](./docs/FEDERAL-AI-LANDSCAPE.md)
 
 ---
 
@@ -167,7 +167,7 @@ agentic-coding-playbook/
 ├── data/
 │   └── federal-ai-landscape.yaml    # Machine-readable guidance registry
 ├── scripts/
-│   ├── playbook_validator/          # Python validation package (369 tests)
+│   ├── playbook_validator/          # Python validation package (370 tests)
 │   └── tests/                       # TDD test suite
 ├── skills/                          # 12 executable compliance procedures
 ├── templates/                       # PROJECT_PLAN.md, AGENTS.md.template

--- a/data/federal-ai-landscape.yaml
+++ b/data/federal-ai-landscape.yaml
@@ -1,15 +1,15 @@
 # federal-ai-landscape.yaml — Machine-readable registry of federal AI guidance
 #
 # Schema: Each entry has: id, title, category, source, date, status, relevance, url
-# Categories: executive_order, omb_memo, nist_standard, legislation, agency_strategy, industry_standard, white_house_plan
+# Categories: executive_order, omb_memo, nist_standard, legislation, agency_strategy, agency_report, industry_standard, white_house_plan
 # Statuses: active, revoked, rescinded, draft, final
 #
 # This file is the single source of truth. docs/FEDERAL-AI-LANDSCAPE.md is generated from it.
 # Last reviewed: 2026-04-06
 
 version: "1.0"
-last_reviewed: "2026-04-06"
-total_entries: 39
+last_reviewed: "2026-06-29"
+total_entries: 42
 
 entries:
 
@@ -165,6 +165,16 @@ entries:
     relevance: "Historical. Established AI acquisition safeguards."
     url: "https://www.whitehouse.gov/wp-content/uploads/2024/10/M-24-18-AI-Acquisition-Memorandum.pdf"
     playbook_phases: []
+
+  - id: m-16-21
+    title: "Federal Source Code Policy: Achieving Efficiency, Transparency, and Innovation through Reusable and Open Source Software"
+    category: omb_memo
+    source: "OMB"
+    date: "2016-08-08"
+    status: active
+    relevance: "Establishes the federal default to release custom-developed code as open source and dedicate it to the public. Basis for publishing GSA-TTS repositories publicly and for the CC0/public-domain posture used by the community-hub repo."
+    url: "https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2016/m_16_21.pdf"
+    playbook_phases: ["0"]
 
   # ── NIST Standards ────────────────────────────────────────────────
 
@@ -358,7 +368,7 @@ entries:
 
   - id: gao-ai-framework
     title: "GAO AI Accountability Framework"
-    category: agency_strategy
+    category: agency_report
     source: "GAO"
     publication_id: "GAO-21-519SP"
     date: "2021-06-01"
@@ -423,7 +433,7 @@ entries:
 
   - id: nist-ssdf
     title: "Secure Software Development Framework (SSDF) v1.1"
-    category: industry_standard
+    category: nist_standard
     source: "NIST"
     publication_id: "SP 800-218"
     date: "2022-02-01"
@@ -442,6 +452,29 @@ entries:
     relevance: "Build provenance and dependency verification for AI supply chain security."
     url: "https://slsa.dev/"
     playbook_phases: ["1"]
+
+  - id: dco-1-1
+    title: "Developer Certificate of Origin 1.1"
+    category: industry_standard
+    source: "Linux Foundation"
+    version: "1.1"
+    date: "2004-05-01"
+    status: active
+    relevance: "Lightweight per-commit provenance attestation (the Signed-off-by sign-off). Basis for requiring that a human — not an agent — certifies the origin and contribution rights of AI-assisted contributions."
+    url: "https://developercertificate.org/"
+    playbook_phases: []
+
+  # ── Agency Reports ────────────────────────────────────────────────
+
+  - id: usco-ai-part2-copyrightability
+    title: "Copyright and Artificial Intelligence, Part 2: Copyrightability"
+    category: agency_report
+    source: "U.S. Copyright Office"
+    date: "2025-01-29"
+    status: active
+    relevance: "States the Office's position that purely AI-generated material lacks the human authorship required for copyright protection. Informs the public-domain / CC0 posture for AI-assisted contributions. Agency position for context, not legal advice."
+    url: "https://www.copyright.gov/ai/Copyright-and-Artificial-Intelligence-Part-2-Copyrightability-Report.pdf"
+    playbook_phases: ["0"]
 
   # ── White House Plans ─────────────────────────────────────────────
 

--- a/docs/AGENT-INSTRUCTIONS.md
+++ b/docs/AGENT-INSTRUCTIONS.md
@@ -16,7 +16,7 @@ Model-agnostic reference for any AI coding agent working in this repository. Rea
 ## Quick Reference
 
 ```bash
-# Validation (Python package — 369 tests)
+# Validation (Python package — 370 tests)
 PYTHONPATH=scripts python3 -m playbook_validator validate-docs
 PYTHONPATH=scripts python3 -m playbook_validator validate-skills
 PYTHONPATH=scripts python3 -m playbook_validator validate-landscape
@@ -117,7 +117,7 @@ keywords: ["security", "NIST"]    # Optional — used for context routing
 
 ## Federal AI Landscape
 
-The `data/federal-ai-landscape.yaml` registry tracks 39 federal AI guidance documents. Key active references:
+The `data/federal-ai-landscape.yaml` registry tracks 42 federal AI guidance documents. Key active references:
 
 - **EO 14179** — Removing Barriers to AI Leadership (Jan 2025)
 - **M-25-21** — AI Governance (Apr 2025, compliance deadline Apr 2026)

--- a/docs/FEDERAL-AI-LANDSCAPE.md
+++ b/docs/FEDERAL-AI-LANDSCAPE.md
@@ -3,18 +3,18 @@ title: "Federal AI Landscape"
 description: "Canonical catalog of federal AI guidance, executive orders, standards, and legislation relevant to AI-assisted software development"
 status: canonical
 tier: 2
-last_updated: "2026-06-01"
+last_updated: "2026-06-29"
 load_priority: on-demand
 audience: ["developers", "isso", "managers", "agents"]
 keywords: ["federal", "AI", "guidance", "executive order", "NIST", "OMB", "OWASP", "compliance", "legislation"]
-last_reviewed: "2026-03-24"
+last_reviewed: "2026-06-29"
 ---
 
 # Federal AI Landscape
 
 Canonical reference for all federal AI guidance relevant to AI-assisted software development. Each entry includes current status, relevance to this playbook, and official source URL.
 
-> **Last reviewed:** 2026-03-24. Federal AI policy is evolving rapidly. Verify status before citing in compliance documents.
+> **Last reviewed:** 2026-06-29. Federal AI policy is evolving rapidly. Verify status before citing in compliance documents.
 >
 > **Machine-readable data:** [`data/federal-ai-landscape.yaml`](../data/federal-ai-landscape.yaml) — structured registry with IDs, dates, statuses, cross-references, and compliance deadlines. Use the YAML for programmatic access; this document is the human-readable companion.
 
@@ -23,13 +23,16 @@ Canonical reference for all federal AI guidance relevant to AI-assisted software
 | Category | Active | Revoked/Rescinded | Draft |
 |---|---|---|---|
 | Executive Orders | 5 | 1 | 0 |
-| OMB Memoranda | 3 | 2 | 0 |
-| NIST Standards | 6 | 0 | 2 |
+| OMB Memoranda | 5 | 2 | 0 |
+| NIST Standards | 8 | 0 | 3 |
 | Federal Legislation | 4 | 0 | 0 |
-| Agency Strategies | 5 | 0 | 0 |
+| Agency Strategies | 4 | 0 | 0 |
+| Agency Reports | 2 | 0 | 0 |
 | Industry Standards | 6 | 0 | 0 |
-| White House Plans | 1 | 0 | 0 |
-| **Total** | **30** | **3** | **2** |
+| White House Plans | 2 | 0 | 0 |
+| **Total** | **36** | **3** | **3** |
+
+> Counts reflect `data/federal-ai-landscape.yaml` (42 entries total; "final" standards counted as Active). `status: final` and `status: active` both denote in-effect references.
 
 ---
 
@@ -98,6 +101,12 @@ Canonical reference for all federal AI guidance relevant to AI-assisted software
 - Two enforceable procurement principles: Truth-Seeking and Ideological Neutrality. Agencies update procurement policies by March 11, 2026. Requires model cards, acceptable use policies, feedback mechanisms from vendors.
 - **Relevance:** All new LLM procurements must comply. Vendors must demonstrate factual accuracy and nonpartisan outputs.
 - **Source:** [whitehouse.gov (PDF)](https://www.whitehouse.gov/wp-content/uploads/2025/12/M-26-04-Increasing-Public-Trust-in-Artificial-Intelligence-Through-Unbiased-AI-Principles-1.pdf)
+
+**M-16-21 — Federal Source Code Policy**
+- **Issued:** August 8, 2016 | **Status:** Active
+- Establishes the federal default to release custom-developed code as open source and to share reusable code across government. Predates the AI memos but remains the policy basis for publishing federal repositories publicly.
+- **Relevance:** Basis for publishing these GSA-TTS repositories in the open and for the CC0 / public-domain dedication posture used by the community-hub repo. Underpins the AI-assisted contribution policy's licensing terms.
+- **Source:** [obamawhitehouse.archives.gov (PDF)](https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2016/m_16_21.pdf)
 
 ### Rescinded
 
@@ -215,17 +224,31 @@ Canonical reference for all federal AI guidance relevant to AI-assisted software
 - **Relevance:** Relevant for defense-adjacent projects. RAI principles align with this playbook's AGENTS.md behavioral contracts.
 - **Source:** [defense.gov (PDF)](https://media.defense.gov/2024/Oct/26/2003571790/-1/-1/0/2024-06-RAI-STRATEGYIMPLEMENTATION-PATHWAY.PDF)
 
+**National Security Memorandum on AI (NSM-25)**
+- **Issued by:** White House/NSC | **Published:** October 24, 2024 | **Status:** Active (Biden-era, not yet revoked)
+- First-ever NSM on AI. Directs government to lead safe AI development, harness AI for national security, advance international AI governance. Companion Framework for AI Governance and Risk Management in National Security.
+- **Relevance:** Sets national security AI requirements that may apply to defense and intelligence-adjacent projects.
+- **Source:** [whitehouse.gov (archived)](https://bidenwhitehouse.archives.gov/briefing-room/statements-releases/2024/10/24/fact-sheet-biden-harris-administration-outlines-coordinated-approach-to-harness-power-of-ai-for-u-s-national-security/)
+
+---
+
+## Agency Reports
+
+Reports and accountability frameworks issued by federal agencies. These state agency
+positions and analysis; they are authoritative as the issuing agency's view but are not
+themselves binding law. Provided for context — not legal advice.
+
 **GAO AI Accountability Framework**
 - **Issued by:** GAO | **Published:** June 2021 (GAO-21-519SP) | **Status:** Active
 - Four pillars: governance, data, performance, monitoring. Used for federal AI audits. 35 recommendations to 19 agencies.
 - **Relevance:** Audit framework. Projects may be evaluated against these pillars.
 - **Source:** [gao.gov](https://www.gao.gov/products/gao-21-519sp)
 
-**National Security Memorandum on AI (NSM-25)**
-- **Issued by:** White House/NSC | **Published:** October 24, 2024 | **Status:** Active (Biden-era, not yet revoked)
-- First-ever NSM on AI. Directs government to lead safe AI development, harness AI for national security, advance international AI governance. Companion Framework for AI Governance and Risk Management in National Security.
-- **Relevance:** Sets national security AI requirements that may apply to defense and intelligence-adjacent projects.
-- **Source:** [whitehouse.gov (archived)](https://bidenwhitehouse.archives.gov/briefing-room/statements-releases/2024/10/24/fact-sheet-biden-harris-administration-outlines-coordinated-approach-to-harness-power-of-ai-for-u-s-national-security/)
+**Copyright and Artificial Intelligence, Part 2: Copyrightability**
+- **Issued by:** U.S. Copyright Office | **Published:** January 29, 2025 | **Status:** Active
+- The Office's position that copyright protection requires human authorship, and that purely AI-generated material is not copyrightable; human creative contribution determines protectability.
+- **Relevance:** Informs the public-domain / CC0 posture for AI-assisted contributions and the licensing terms in the AI-assisted contribution policy. Agency position for context, not legal advice.
+- **Source:** [copyright.gov (PDF)](https://www.copyright.gov/ai/Copyright-and-Artificial-Intelligence-Part-2-Copyrightability-Report.pdf)
 
 ---
 
@@ -269,7 +292,7 @@ These complement federal guidance and are referenced throughout this playbook.
 
 **NIST SP 800-218 — Secure Software Development Framework (SSDF) v1.1**
 - **Organization:** NIST | **Version:** 1.1 (February 2022) | **Status:** Final
-- Baseline secure development practices mandated by EO 14028 for all federal software.
+- Baseline secure development practices mandated by EO 14028 for all federal software. (Categorized as a NIST standard in the registry; listed here for proximity to the supply-chain references it underpins.)
 - **Relevance:** Foundation for CODING_PRACTICES.md. SP 800-218A extends this for AI-specific practices.
 - **Source:** [csrc.nist.gov](https://csrc.nist.gov/publications/detail/sp/800-218/final)
 
@@ -278,6 +301,12 @@ These complement federal guidance and are referenced throughout this playbook.
 - Build provenance, source integrity, and dependency verification framework.
 - **Relevance:** Model provenance and training data integrity for AI supply chain security.
 - **Source:** [slsa.dev](https://slsa.dev/)
+
+**Developer Certificate of Origin (DCO) 1.1**
+- **Organization:** Linux Foundation | **Version:** 1.1 (2004) | **Status:** Active
+- Lightweight per-commit provenance attestation — the `Signed-off-by` sign-off by which a contributor certifies they have the right to submit the contribution.
+- **Relevance:** Basis for requiring that a human (not an agent) certifies the origin and contribution rights of AI-assisted contributions. Used by the AI-assisted contribution policy.
+- **Source:** [developercertificate.org](https://developercertificate.org/)
 
 ---
 

--- a/scripts/playbook_validator/validate_landscape.py
+++ b/scripts/playbook_validator/validate_landscape.py
@@ -18,6 +18,7 @@ VALID_CATEGORIES = frozenset(
         "nist_standard",
         "legislation",
         "agency_strategy",
+        "agency_report",
         "industry_standard",
         "white_house_plan",
     }

--- a/scripts/tests/test_validate_landscape.py
+++ b/scripts/tests/test_validate_landscape.py
@@ -69,6 +69,27 @@ class TestValidateLandscape:
         errors, warnings, _count = validate_landscape(_write_yaml(tmp_path, data))
         assert any("category" in e for e in errors)
 
+    def test_agency_report_category_is_valid(self, tmp_path):
+        """agency_report is an accepted category (GAO/USCO-style reports)."""
+        data = {
+            "version": "1.0",
+            "total_entries": 1,
+            "entries": [
+                {
+                    "id": "usco-test",
+                    "title": "Copyright and Artificial Intelligence, Part 2",
+                    "category": "agency_report",
+                    "source": "U.S. Copyright Office",
+                    "date": "2025-01-29",
+                    "status": "active",
+                    "relevance": "Agency position for context; not legal advice.",
+                    "url": "https://www.copyright.gov/ai/",
+                }
+            ],
+        }
+        errors, warnings, _count = validate_landscape(_write_yaml(tmp_path, data))
+        assert not any("category" in e for e in errors)
+
     def test_invalid_status(self, tmp_path):
         data = {
             "version": "1.0",


### PR DESCRIPTION
## Summary

Federal-AI-landscape **tracker correctness** pass. This is the prerequisite for an upcoming AI-assisted contribution policy (separate PR) that will source its federal citations from this registry — so the registry needs the right taxonomy and the right entries first.

### Taxonomy
- Add **`agency_report`** to `VALID_CATEGORIES` (validator + new test). Houses agency reports / accountability frameworks that are neither strategies nor binding standards.

### Realignments (correctness)
- `gao-ai-framework`: `agency_strategy` → `agency_report` (it's an accountability report, not a strategy).
- `nist-ssdf`: `industry_standard` → `nist_standard` (it's a NIST publication — consistent with the other 8 NIST entries).

### New entries (verified against primary sources)
- **`m-16-21`** — OMB Federal Source Code Policy (2016, active). Basis for public release + the CC0/public-domain posture.
- **`dco-1-1`** — Developer Certificate of Origin 1.1 (Linux Foundation). Human provenance attestation (`Signed-off-by`).
- **`usco-ai-part2-copyrightability`** — U.S. Copyright Office (2025). Agency position on the human-authorship requirement; informs the CC0 posture. **Framed as agency position / context, explicitly not legal advice.**

### Docs
- Sync `docs/FEDERAL-AI-LANDSCAPE.md` (it was hand-maintained and stale): corrected Status Summary (now **36 active / 3 / 3** across **42** entries), added an **Agency Reports** section (GAO + USCO), the M-16-21 OMB entry, and DCO 1.1; refreshed dates.
- `total_entries` 39 → 42; `last_reviewed` → 2026-06-29. Regenerated INDEX/README/CONTEXT-GUIDE/AGENT-INSTRUCTIONS.

> ⚠️ Note: `docs/FEDERAL-AI-LANDSCAPE.md` is **hand-maintained** even though the YAML header claims it's generated. Filing a follow-up issue to add a generator so it can't drift again.

## Verification
- `scripts/ci-local.sh` → **10/10** (ruff lint+format, markdownlint, pytest **370**, validate-docs/landscape/skills, INDEX freshness, Semgrep SAST 0 findings, pip-audit no known vulns)
- `validate-landscape` → OK (42 entries)

> CI note: GitHub Actions is currently blocked org-wide by an unrelated billing/quota issue; validated locally via `scripts/ci-local.sh`.

## Type of Change
- [x] Feature (data/tooling) — additive taxonomy + registry entries + doc sync

🤖 AI-assisted (OpenCode).