### PR TITLE
feat(agents): require human approval to accept licenses; prefer unencumbered tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@ tier: 1
 contract:
   role: universal
   version: "1.0.0"
-last_updated: "2026-07-06"
-nist_controls: ["AC-2", "AC-3", "AC-6", "AU-2", "AU-3", "AU-12", "CM-2", "CM-3", "CM-5", "CM-6", "CM-7", "IA-8", "IR-4", "IR-6", "PL-4", "SA-5", "SA-8", "SA-11", "SA-15", "SA-17", "SC-7", "SC-8", "SC-13", "SI-10", "SI-17", "SR-3"]
+last_updated: "2026-07-22"
+nist_controls: ["AC-2", "AC-3", "AC-6", "AU-2", "AU-3", "AU-12", "CM-2", "CM-3", "CM-5", "CM-6", "CM-7", "CM-10", "IA-8", "IR-4", "IR-6", "PL-4", "SA-4", "SA-5", "SA-8", "SA-11", "SA-15", "SA-17", "SC-7", "SC-8", "SC-13", "SI-10", "SI-17", "SR-3"]
 frameworks: ["NIST SP 800-53 Rev 5.2", "NIST AI RMF 1.0", "NIST AI 600-1", "NCCOE Agent Identity", "OWASP Top 10 LLM 2025", "OWASP Top 10 Agentic 2026"]
 audience: "all"
 keywords: ["agent-rules", "behavioral-contract", "least-privilege", "audit-logging", "prompt-injection", "prohibited-actions", "meta-constraints", "plan-before-execute", "verification-transcript", "engineering-discipline"]
@@ -184,6 +184,7 @@ The agent MUST obtain explicit user approval before:
 - Executing destructive operations (deleting files, dropping databases, force-pushing)
 - Making network requests to external services
 - Installing or upgrading dependencies
+- Accepting a software license or EULA on the organization's behalf (e.g. click-through terms, `--accept-license` / `accept-silent`-style flags) — accepting terms is a commitment the human must make
 - Modifying CI/CD pipeline configurations
 - Committing or pushing code to remote repositories
 - Accessing or processing data classified above the current authorization level
@@ -250,11 +251,13 @@ The agent MUST:
 - Check for known vulnerabilities before adding new dependencies
 - Prefer dependencies with active maintenance and security track records
 - Minimize the number of dependencies — use standard library equivalents when available
+- Not auto-accept a dependency's or tool's license terms on the organization's behalf; surface the license and its federal-use compatibility for human approval before proceeding
 
 The agent SHOULD:
 - Generate or update the Software Bill of Materials (SBOM) when dependencies change
 - Verify package integrity (checksums, signatures) when available
 - Prefer dependencies from trusted registries
+- Prefer license-unencumbered equivalents where they exist and are otherwise suitable (e.g. CINC Auditor in place of Chef InSpec), to avoid commercial license-acceptance steps
 
 ### 5.3 Error Handling
 
@@ -279,7 +282,7 @@ The agent SHOULD:
 - When using memory-unsafe languages (C, C++), use compiler hardening flags and static analysis
 - Follow CISA memory safety guidance for language selection
 
-> **Control Mapping:** SI-10 (Input Validation), SA-11 (Developer Testing), SC-13 (Cryptographic Protection), SA-15 (Development Process)
+> **Control Mapping:** SI-10 (Input Validation), SA-11 (Developer Testing), SC-13 (Cryptographic Protection), SA-15 (Development Process), SA-4 (Acquisition Process), CM-10 (Software Usage Restrictions)
 
 ---
 
@@ -726,6 +729,7 @@ Each section above includes inline control mappings (e.g., `> **Control Mapping:
 
 | Date | Version | Change |
 |------|---------|--------|
+| 2026-07-22 | 0.4.0 | Add license-acceptance rules: §3.2 requires human approval before accepting a license/EULA on the org's behalf; §5.2 forbids auto-accepting license terms and prefers license-unencumbered equivalents (e.g. CINC over Chef InSpec); add SA-4, CM-10 mappings |
 | 2026-07-06 | 0.3.0 | Split into universal contract + thin project layer; add fail-closed contract-prerequisite probe; designate canonical via a versioned `contract:` frontmatter block (`role: universal`, `version: 1.0.0`) recognized by structure, not content |
 | 2026-06-26 | 0.2.0 | Add §8.3 periodic end-to-end validation, §9.3 discovered-defect filing gate, §14.1.1 plan proportionality + expedited mode, §15.5 track-all-work, wiring/downstream self-check items; reconcile version banner + related_files; drop hardcoded test count |
 | 2026-02-25 | 0.1.0 | Initial release — MVP scope (single-agent, FIPS Moderate, internal enterprise) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,7 +257,7 @@ The agent SHOULD:
 - Generate or update the Software Bill of Materials (SBOM) when dependencies change
 - Verify package integrity (checksums, signatures) when available
 - Prefer dependencies from trusted registries
-- Prefer license-unencumbered equivalents where they exist and are otherwise suitable (e.g. CINC Auditor in place of Chef InSpec), to avoid commercial license-acceptance steps
+- Prefer license-unencumbered equivalents where they exist and are otherwise suitable (e.g. reads and write the same input/output formats, implements the same specification, fulfills a well-established role), to avoid commercial license-acceptance steps
 
 ### 5.3 Error Handling
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ status: canonical
 tier: 1
 contract:
   role: universal
-  version: "1.0.0"
+  version: "0.4.0"
 last_updated: "2026-07-22"
 nist_controls: ["AC-2", "AC-3", "AC-6", "AU-2", "AU-3", "AU-12", "CM-2", "CM-3", "CM-5", "CM-6", "CM-7", "CM-10", "IA-8", "IR-4", "IR-6", "PL-4", "SA-4", "SA-5", "SA-8", "SA-11", "SA-15", "SA-17", "SC-7", "SC-8", "SC-13", "SI-10", "SI-17", "SR-3"]
 frameworks: ["NIST SP 800-53 Rev 5.2", "NIST AI RMF 1.0", "NIST AI 600-1", "NCCOE Agent Identity", "OWASP Top 10 LLM 2025", "OWASP Top 10 Agentic 2026"]

--- a/CONTEXT-GUIDE.md
+++ b/CONTEXT-GUIDE.md
@@ -23,13 +23,13 @@ review_cycle: "quarterly"
 3. **Load on demand** — do NOT load all documents preemptively
 4. **Security is non-negotiable** — when in doubt about a security requirement, load the relevant doc rather than guessing
 
-## Tier 1 — Always Load (~15,216 words)
+## Tier 1 — Always Load (~15,341 words)
 
 These define the behavioral contract. Load for **every task**.
 
 | Document | Words | What It Covers |
 |----------|-------|----------------|
-| `AGENTS.md` | 5,490 | Agent rules: permissions, prohibitions, data handling, identity, meta-constraints |
+| `AGENTS.md` | 5,615 | Agent rules: permissions, prohibitions, data handling, identity, meta-constraints |
 | `PLAYBOOK.md` | 1,202 | Step-by-step guide: project setup → deployment (9 phases, 12 skills) |
 | `docs/CODING_PRACTICES.md` | 6,886 | Secure coding: input validation, secrets, dependencies, architecture, TDD, SOLID |
 | `docs/CODING_STANDARDS_COMPACT.md` | 450 | **Code generation shortcut** — load INSTEAD of full CODING_PRACTICES.md for routine code tasks |

--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -7,10 +7,10 @@
 # before making changes that span multiple documents.
 #
 # Schema version: 1.0
-# Last generated: 2026-07-07
+# Last generated: 2026-07-22
 
 schema_version: "1.0"
-generated: "2026-07-07"
+generated: "2026-07-22"
 repo: "GSA-TTS/agentic-coding-playbook"
 scope: "FIPS Moderate | Single-agent | Internal enterprise"
 
@@ -38,9 +38,9 @@ documents:
     status: canonical
     tier: 1
     load_priority: always
-    last_updated: "2026-07-06"
+    last_updated: "2026-07-22"
     audience: all
-    nist_controls_count: 26
+    nist_controls_count: 28
     review_cycle: quarterly
 
   - path: "CONTEXT-GUIDE.md"
@@ -338,5 +338,5 @@ stats:
   tier_1_core: 9
   tier_2_supporting: 6
   tier_3_templates: 8
-  total_nist_controls_referenced: 56
+  total_nist_controls_referenced: 57
   frameworks_covered: 21


### PR DESCRIPTION
## Context

Closes #162.

While working in a downstream repo (`cloud-gov/aws-broker`), an agent coded a `cinc-auditor` invocation that included `--chef-license accept-silent` — silently accepting a license on the organization's behalf. The universal contract had no rule covering license/EULA acceptance as a human-in-the-loop commitment, and no guidance to prefer license-unencumbered equivalents (CINC is precisely the license-free InSpec rebuild).

"Never accept a license" would be over-broad and unworkable (installing deps, pulling images, etc. all involve terms). This PR instead targets *accepting terms on the org's behalf without approval*, and adds a preference heuristic.

## Plan / What changed

- **§3.2 Human-in-the-Loop Requirements** — new MUST-approve bullet: accepting a software license or EULA on the organization's behalf (click-through, `--accept-license` / `accept-silent`-style flags).
- **§5.2 Dependency Management** — new MUST (do not auto-accept license terms; surface for approval) + new SHOULD (prefer license-unencumbered equivalents, e.g. CINC Auditor over Chef InSpec).
- **Control mapping** — added SA-4 (Acquisition Process) and CM-10 (Software Usage Restrictions) to §5.2 and to frontmatter `nist_controls`.
- Bumped `last_updated` (2026-07-22) and added a 0.4.0 Version History row.
- Regenerated `INDEX.yaml` and `CONTEXT-GUIDE.md` word counts via `make generate`.

## Verification

```
make validate-docs   → Errors: 0; All validations passed
make generate-check  → OK: INDEX.yaml is up to date
```

- INDEX.yaml `nist_controls_count` for AGENTS.md updated 26 → 28.
- CONTEXT-GUIDE.md Tier-1 word counts regenerated (no manual edits).

## Rollback

Revert this commit (`git revert 2309699`) — docs-only change, no code paths affected.

## Security Impact

Tightens agent behavior (adds an approval gate + a supply-chain preference). Does not weaken any control. Relevant controls: AC-6, CM-5, CM-7, SA-4, CM-10.

> AI-assisted: authored by an AI agent under human direction; requires human review before merge.
