### PR TITLE
fix(deps): resolve npm audit highs in CI linter deps

### DIFF
--- a/.github/linters/package-lock.json
+++ b/.github/linters/package-lock.json
@@ -395,9 +395,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -408,7 +408,6 @@
           "url": "https://github.com/sponsors/nodeca"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -448,9 +447,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",
@@ -461,15 +460,14 @@
           "url": "https://github.com/sponsors/markdown-it"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
-      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
       "funding": [
         {
           "type": "github",
@@ -480,11 +478,10 @@
           "url": "https://github.com/sponsors/markdown-it"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -1262,8 +1259,7 @@
     "node_modules/uc.micro": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "license": "MIT"
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
     },
     "node_modules/unicorn-magic": {
       "version": "0.4.0",

--- a/.github/linters/package.json
+++ b/.github/linters/package.json
@@ -10,7 +10,7 @@
     "markdownlint-cli2": "0.22.1"
   },
   "overrides": {
-    "js-yaml": "4.2.0",
-    "markdown-it": "14.2.0"
+    "js-yaml": "4.3.0",
+    "markdown-it": "14.3.0"
   }
 }


### PR DESCRIPTION
## Context

`npm audit` reported **3 high-severity** advisories in the pinned CI linter deps under `.github/linters/`, all transitive under `markdownlint-cli2@0.22.1`:

- `js-yaml` ≤4.2.0 — GHSA-52cp-r559-cp3m (quadratic CPU via YAML merge-key chains)
- `linkify-it` ≤5.0.1 — GHSA-v245-v573-v5vm (quadratic DoS in the `mailto:` validator scan-loop)
- `markdown-it` — pulled in the vulnerable `linkify-it`

## Plan / What changed

Bumped the two existing `overrides` in `.github/linters/package.json` to the nearest patched, semver-compatible versions, and regenerated the lockfile:

- `js-yaml` `4.2.0` → `4.3.0`
- `markdown-it` `14.2.0` → `14.3.0` (brings `linkify-it@5.0.2`, which is fixed)

Deliberately avoided `npm audit fix --force`, which would bump `markdownlint-cli2` to `0.23.1` — a breaking major of the intentionally pinned tool (the file's stated purpose is "Pinned linter dependencies for CI supply chain security"). This keeps `markdownlint-cli2@0.22.1` unchanged.

## Verification

```
npm audit        → found 0 vulnerabilities   (was 3 high)
npm ci           → clean; js-yaml@4.3.0, markdown-it@14.3.0, linkify-it@5.0.2 (overridden)
npm run lint:md  → 0 error(s)                 (linter still runs)
```

## Rollback

Revert this commit (`git revert 9d932bc`) — deps-only change to the CI linter package; no application code affected.

## Security Impact

Reduces attack surface (clears 3 high DoS advisories). No control weakened. Supply-chain relevant: SR-3, RA-5.

> AI-assisted: authored by an AI agent under human direction; requires human review before merge.
