### PR TITLE
feat(validator): guard SECURITY-CONTROLS.md control-count integrity (#121)

### DIFF
--- a/scripts/playbook_validator/__main__.py
+++ b/scripts/playbook_validator/__main__.py
@@ -26,6 +26,7 @@ def cmd_validate_docs(args: argparse.Namespace) -> int:
         find_content_files,
         validate_contract_role,
         validate_doc_frontmatter,
+        validate_security_controls_count,
     )
 
     root = Path(args.root)
@@ -52,6 +53,16 @@ def cmd_validate_docs(args: argparse.Namespace) -> int:
         print(f"WARNING: {w}")
     if not role_errors:
         print("  OK: canonical universal contract designated; thin layers do not claim it")
+
+    print("\n=== Security-Controls Count Integrity ===")
+    sc_errors, sc_warnings = validate_security_controls_count(root)
+    for e in sc_errors:
+        print(f"ERROR: {e}")
+        total_errors += 1
+    for w in sc_warnings:
+        print(f"WARNING: {w}")
+    if not sc_errors:
+        print("  OK: SECURITY-CONTROLS.md frontmatter count matches documented control rows")
 
     print(f"\n=== Summary ===\nErrors: {total_errors}")
     if total_errors > 0:

--- a/scripts/playbook_validator/validate_docs.py
+++ b/scripts/playbook_validator/validate_docs.py
@@ -4,6 +4,7 @@ Validates that all content Markdown files have correct frontmatter
 with required fields and valid enum values.
 """
 
+import re
 from pathlib import Path
 
 from playbook_validator.config import (
@@ -126,6 +127,70 @@ def validate_doc_frontmatter(path: Path) -> tuple[list[str], list[str]]:
                 vval = block.get(vkey)
                 if vval is not None and (not isinstance(vval, str) or not vval.strip()):
                     errors.append(f"{path} — contract.{vkey} must be a non-empty string")
+
+    return errors, warnings
+
+
+# Control-overlay body rows look like: | **AC-2** | Account Management | ...
+# One row per NIST control documented in docs/SECURITY-CONTROLS.md.
+_CONTROL_ROW_RE = re.compile(r"^\|\s*\*\*([A-Z]{2}-\d{1,2})\*\*\s*\|", re.MULTILINE)
+_SECURITY_CONTROLS_REL = "docs/SECURITY-CONTROLS.md"
+
+
+def validate_security_controls_count(root: Path) -> tuple[list[str], list[str]]:
+    """Assert SECURITY-CONTROLS.md frontmatter matches its documented controls.
+
+    The frontmatter ``nist_controls`` array is what machine consumers (INDEX.yaml,
+    traceability) read; the body has one ``| **XX-N** |`` table row per control.
+    If they diverge, consumers get a wrong count and the prose "N controls" claim
+    drifts (issue #121). This guard fails closed so the two can never silently
+    disagree again. It also flags an inline "N controls" prose count that no
+    longer matches.
+
+    Returns (errors, warnings).
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    doc = root / _SECURITY_CONTROLS_REL
+    if not doc.is_file():
+        # Not every consumer repo ships this doc; absence is not an error here.
+        return errors, warnings
+
+    text = doc.read_text(encoding="utf-8")
+    fm = extract_frontmatter(doc) or {}
+    fm_controls = fm.get("nist_controls") or []
+    fm_count = len(fm_controls)
+
+    # Body: distinct controls that actually have a documented row.
+    body = text.split("---\n", 2)[2] if text.startswith("---\n") else text
+    body_controls = sorted(set(_CONTROL_ROW_RE.findall(body)))
+    body_count = len(body_controls)
+
+    if fm_count != body_count:
+        fm_set, body_set = set(fm_controls), set(body_controls)
+        only_fm = sorted(fm_set - body_set)
+        only_body = sorted(body_set - fm_set)
+        detail = []
+        if only_fm:
+            detail.append(f"in frontmatter but not documented: {only_fm}")
+        if only_body:
+            detail.append(f"documented but not in frontmatter: {only_body}")
+        errors.append(
+            f"{doc} — nist_controls count ({fm_count}) != documented control rows "
+            f"({body_count}). {'; '.join(detail) if detail else 'counts differ'}. "
+            "Reconcile the frontmatter array with the body table (issue #121)."
+        )
+
+    # Advisory: an inline "N controls" prose claim that disagrees with the truth.
+    for m in re.finditer(r"(\d+)\s+controls\b", text):
+        claimed = int(m.group(1))
+        if claimed != body_count:
+            warnings.append(
+                f"{doc} — prose says '{claimed} controls' but {body_count} are "
+                f"documented; update the prose to match (issue #121)."
+            )
+            break
 
     return errors, warnings
 

--- a/scripts/tests/test_validate_docs.py
+++ b/scripts/tests/test_validate_docs.py
@@ -266,3 +266,68 @@ class TestFindContentFiles:
         )
         files = find_content_files(tmp_path)
         assert "0001-some-decision.md" not in [f.name for f in files]
+
+
+class TestSecurityControlsCount:
+    """Guard that SECURITY-CONTROLS.md frontmatter count == documented rows (#121)."""
+
+    def _write(self, tmp_path, controls, rows, prose_n=None):
+        docs = tmp_path / "docs"
+        docs.mkdir(exist_ok=True)
+        arr = ", ".join(f'"{c}"' for c in controls)
+        body_rows = "\n".join(f"| **{c}** | Name | P1 | desc | impl | verify | xref |" for c in rows)
+        prose = f"\n{prose_n} controls across 10 families.\n" if prose_n is not None else ""
+        (docs / "SECURITY-CONTROLS.md").write_text(
+            f"---\ntitle: SC\nstatus: canonical\ntier: 1\nnist_controls: [{arr}]\n---\n"
+            f"# Security Controls\n{prose}\n"
+            "| Control | Name | Priority | Description | Impl | Verify | Xref |\n"
+            "|---|---|---|---|---|---|---|\n"
+            f"{body_rows}\n"
+        )
+
+    def test_matching_counts_pass(self, tmp_path):
+        from playbook_validator.validate_docs import validate_security_controls_count
+
+        self._write(tmp_path, ["AC-2", "AC-3", "CM-6"], ["AC-2", "AC-3", "CM-6"], prose_n=3)
+        errors, warnings = validate_security_controls_count(tmp_path)
+        assert errors == []
+        assert warnings == []
+
+    def test_frontmatter_undercount_fails(self, tmp_path):
+        from playbook_validator.validate_docs import validate_security_controls_count
+
+        # 2 in frontmatter, 3 documented — the exact #121 drift.
+        self._write(tmp_path, ["AC-2", "AC-3"], ["AC-2", "AC-3", "CM-6"])
+        errors, _ = validate_security_controls_count(tmp_path)
+        assert errors and "CM-6" in errors[0]
+
+    def test_frontmatter_overcount_fails(self, tmp_path):
+        from playbook_validator.validate_docs import validate_security_controls_count
+
+        self._write(tmp_path, ["AC-2", "AC-3", "SI-99"], ["AC-2", "AC-3"])
+        errors, _ = validate_security_controls_count(tmp_path)
+        assert errors and "SI-99" in errors[0]
+
+    def test_prose_count_mismatch_warns(self, tmp_path):
+        from playbook_validator.validate_docs import validate_security_controls_count
+
+        self._write(tmp_path, ["AC-2", "AC-3"], ["AC-2", "AC-3"], prose_n=99)
+        errors, warnings = validate_security_controls_count(tmp_path)
+        assert errors == []
+        assert warnings and "99 controls" in warnings[0]
+
+    def test_absent_doc_is_noop(self, tmp_path):
+        from playbook_validator.validate_docs import validate_security_controls_count
+
+        errors, warnings = validate_security_controls_count(tmp_path)
+        assert errors == [] and warnings == []
+
+    def test_real_repo_is_consistent(self):
+        """The live docs/SECURITY-CONTROLS.md must pass the guard."""
+        from pathlib import Path
+
+        from playbook_validator.validate_docs import validate_security_controls_count
+
+        root = Path(__file__).resolve().parents[2]
+        errors, _ = validate_security_controls_count(root)
+        assert errors == [], f"live SECURITY-CONTROLS.md drift: {errors}"


### PR DESCRIPTION
Closes #121.

## Context
The reported drift — `docs/SECURITY-CONTROLS.md` frontmatter `nist_controls` listing a different count than the body/prose — was **already reconciled** in #123 (everything is consistent at **35** on main: frontmatter array, `| **XX-N** |` body rows, and the "35 controls" prose). But #121's second ask — *a guard so it can't drift again* — was never implemented. This PR adds it.

## What changed
- **`validate_docs.py`** — new `validate_security_controls_count()`:
  - asserts `len(nist_controls)` == count of documented `| **XX-N** |` control rows, and reports **which** controls are on one side but not the other;
  - advisory warning when an inline "N controls" prose claim disagrees with the documented count;
  - no-op when the doc is absent (consumer repos that don't ship it).
- **`__main__.py`** — wired into `validate-docs` as a new "Security-Controls Count Integrity" section; contributes to the exit code.
- **tests** — matching counts pass; frontmatter under/overcount fail with the offending control id; prose mismatch warns; absent-doc no-op; plus a live-repo consistency test.

## Verification
- Guard **green** on main's 35/35; I injected a dropped control (`SR-11`) and confirmed it **fails closed** with a precise message, then reverted.
- Full suite **431 passed**; `validate-docs` green; ruff clean.
- Net change to existing code is zero (pure additions) — restored `validate_doc_frontmatter` verbatim after an intermediate edit.

Doc/validator change, PR-gated for human review.

Co-authored-by: OpenCode Agent <william.zujkowski@gsa.gov>