### PR TITLE
chore(landscape): review federal AI registry — no new governance docs (2026-08-04)

### DIFF
--- a/data/federal-ai-landscape.yaml
+++ b/data/federal-ai-landscape.yaml
@@ -8,7 +8,7 @@
 # Last reviewed: 2026-04-06
 
 version: "1.0"
-last_reviewed: "2026-06-29"
+last_reviewed: "2026-08-04"
 total_entries: 42
 
 entries:


### PR DESCRIPTION
## Summary

Periodic review of the federal AI landscape registry. Bumps `last_reviewed` to **2026-08-04**; no entries added or changed — the 42-entry registry is confirmed current.

## How it was reviewed

- Ran `scripts/landscape_monitor.py` live against the White House, NIST CSRC, and Federal Register AI feeds.
- Cross-checked with the authoritative Federal Register **Presidential-Documents** API for anything since the prior review (2026-06-29).

## Findings

- **No new AI-governance actions** since 2026-06-29. The only PRESDOCU matches were a defense supply-chain EO and a July 4th proclamation that merely *mention* AI (not governance); the RSS "new" hits were Federal-Register noise (grant/committee/export notices), not policy.
- Registry remains accurate at 42 entries.

## Verification

`make validate-landscape` → 42 entries validated, all checks passed. Data-only (one line).

Note: a separate issue tracks tightening the Federal Register RSS query (the `term=artificial intelligence` filter is too broad and surfaces false positives).

AI-assisted (OpenCode); requires human review.