### PR TITLE
docs: public-readiness governance files + scope reframe

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Code of Conduct
+
+## Our standard
+
+This project is part of the U.S. General Services Administration's Technology
+Transformation Services (GSA TTS). We are committed to providing a welcoming,
+respectful, and professional environment for everyone who takes part in this
+community — maintainers, contributors, and members of the public.
+
+We expect all participants to:
+
+- Be respectful and professional in all interactions.
+- Use clear, plain language and assume good faith.
+- Give and accept constructive feedback gracefully.
+- Focus on what is best for the community and the work.
+
+The following behavior is not tolerated:
+
+- Harassment or discrimination of any kind.
+- Insulting, demeaning, or derogatory comments, or personal attacks.
+- Publishing others' private information without their explicit permission.
+- Sexualized language or imagery, or unwelcome sexual attention.
+- Any other conduct that would reasonably be considered inappropriate in a
+  professional setting.
+
+## Federal Community Addendum
+
+This addendum **supplements** the standard above; it does not replace it. Where
+any conflict exists, the stricter expectation applies.
+
+- **Federal government community space.** This is a U.S. federal government
+  community. Participants include federal employees and contractors, and the
+  professional conduct expectations of the federal workplace apply here.
+- **Critique the work, never the person.** This repository maintains a
+  contribution-quality bar. All feedback on a contribution — including quality
+  and scope feedback — MUST target the *artifact* (a pull request, document, or
+  idea), never the contributor or any aspect of their identity. Saying "this PR
+  is out of scope for this repo" is fine; making it about the person is not.
+- **No sensitive data, anywhere.** Do not post secrets, credentials, PII, CUI,
+  or non-public government data in any issue, pull request, comment, example, or
+  other interaction. This mirrors the repository's prohibited-content rules.
+- **Plain language and accessibility are community values.** Prefer clear,
+  plain-language communication and accessible content, consistent with GSA
+  norms.
+- **Assume good faith.** Most mis-scoped or low-quality contributions are honest
+  mistakes, not bad-faith conduct. Quality and scope issues are handled through
+  normal review — not through conduct enforcement. Reserve conduct enforcement
+  for *conduct*, not for contribution quality or scope.
+- **Accountability is about the artifact, not the person.** If a contributor
+  cannot explain a change, that is **feedback on the code** — the change simply
+  isn't ready to merge yet, and it is handled through normal code review. It is
+  **never** misconduct and is never a judgment about the contributor as a person.
+  Do not use an accountability or quality finding as a backdoor conduct sanction.
+
+## Scope
+
+This Code of Conduct applies within all project spaces (issues, pull requests,
+comments, and other repository interactions) and when an individual is
+officially representing the project in public spaces.
+
+## Reporting and enforcement
+
+To report a code-of-conduct concern for this project, email
+**agentic-coding@gsa.gov** with the subject prefixed `[CONDUCT]`. Reports are
+read by the repository maintainers, who will review and respond as promptly and
+fairly as they reasonably can, and who will respect the privacy of the reporter.
+
+Maintainers are responsible for clarifying and enforcing this standard and may
+take any action they deem appropriate, up to and including removing content or
+barring a participant from the project, in response to behavior that violates
+this Code of Conduct.
+
+Security vulnerabilities are **not** handled here — see
+[SECURITY.md](SECURITY.md) for how to report those.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thank you for your interest in improving the Agentic Coding Playbook! This is an internal repository that benefits from input by practitioners across GSA.
+Thank you for your interest in improving the Agentic Coding Playbook! This repository welcomes input from practitioners across GSA and the broader federal community.
 
 ## Ecosystem Overview
 
@@ -24,7 +24,7 @@ This repo is one of three in the agentic coding ecosystem:
 
 The simplest approach:
 
-1. **Fix it directly** — Submit a PR (preferred for internal repos)
+1. **Fix it directly** — Submit a PR
 2. **Not sure how?** — Open an issue to discuss first
 3. **Questions?** — Ask in the agentic-coding Slack channel
 
@@ -405,7 +405,19 @@ All pull requests require review. Changes to security standards require addition
 
 ## Code of Conduct
 
-Be professional, constructive, and respectful. Quality and accuracy matter.
+This project follows its [Code of Conduct](CODE_OF_CONDUCT.md). Be professional,
+constructive, and respectful; quality and accuracy matter.
+
+## Public domain
+
+This project is in the public domain within the United States, and copyright and
+related rights in the work worldwide are waived through the
+[CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+See [`LICENSE`](LICENSE) for details.
+
+All contributions to this project will be released under the CC0 dedication. By
+submitting a pull request or issue, you are agreeing to comply with this waiver
+of copyright interest.
 
 ## Share What You Learn
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,12 @@ The agent reads your plan and sets up everything: `AGENTS.md`, coding standards,
 
 A set of markdown files, templates, and validation tools that help AI coding agents follow **secure-by-default practices** when assisting federal employees with software development. Drop these files into any repository to establish consistent behavioral standards across the full development lifecycle.
 
-Designed for **FIPS Moderate** systems, **single-agent** architectures, and **internal enterprise** environments.
+A practical, living approach to secure AI-assisted development for federal
+teams — usable across single-agent and multi-agent ("swarm") workflows, and
+spanning backend, frontend, accessibility/Section 508, and the full development
+lifecycle. It is grounded in current federal requirements and security and
+software-development best practices; it is **not** authoritative federal policy,
+and it does not replace your agency's own authorization decisions.
 
 ## The Two-Layer Contract
 
@@ -215,11 +220,29 @@ agentic-coding-playbook/
 
 ---
 
-## Scope
+## Where this applies
 
-**In scope:** Single-agent systems, internal enterprise apps, FIPS Moderate, full SDLC.
+- **Agentic workflows:** single-agent and multi-agent / swarm approaches. (Note:
+  multi-agent patterns add threat surface — inter-agent prompt injection, wider
+  tool/credential blast radius — and our guidance there is still maturing.)
+- **Across the stack:** backend, public-facing and frontend work, and
+  accessibility / Section 508.
+- **Security baseline:** written against a **FIPS Moderate** baseline; adapt the
+  controls to your own system's impact level and ATO.
+- **Lifecycle:** the full software development lifecycle.
 
-**Out of scope:** Multi-agent orchestration, FIPS High/classified, public-facing AI services, ML training pipelines, procurement guidance (see [OMB M-25-22](https://www.whitehouse.gov/)).
+## What this is not
+
+- **Not authoritative federal policy** and not a substitute for your agency's
+  security authorization (ATO) process. Confirm any requirement against its
+  current authoritative source (NIST, OMB, your agency) — this repo is a
+  practical snapshot, not the system of record.
+- **Not a foundation for FIPS High or classified systems.** Consult your
+  agency's security team for those contexts.
+- **Not procurement guidance** — see
+  [OMB M-25-22](https://www.whitehouse.gov/).
+- **Community-maintained and evolving.** Methods here are community-tested, not
+  guaranteed; provided as-is under [CC0 1.0](./LICENSE) with no warranty.
 
 ---
 
@@ -227,7 +250,7 @@ agentic-coding-playbook/
 
 We welcome contributions from the agentic coding community.
 
-- **Fix it directly** — Submit a PR (preferred for internal repos)
+- **Fix it directly** — Submit a PR
 - **Questions** — Ask in the agentic-coding Slack channel
 - **Not sure how?** — Open an issue to discuss
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,80 +1,48 @@
 # Security Policy
 
+## About this repository
+
+The `agentic-coding-playbook` is a living, community-maintained repository that
+captures a practical approach to implementing current federal requirements
+alongside security and software-development best practices for AI-assisted work.
+It is **not** an authoritative source of federal policy or standards. It contains
+documentation, templates, and validation tooling (shell and Python) — there is no
+hosted service, and it processes no user data.
+
+Because of that, the security issues that matter here are things like: unsafe
+example commands or code, a supply-chain problem in the repository's own tooling,
+or credentials accidentally committed to the repository.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security vulnerability.**
+
+1. **Preferred — GitHub private Security Advisories.** Open a report from this
+   repository's **Security → Report a vulnerability** tab. This keeps the details
+   private while we look into them.
+2. **Email.** If you can't use Security Advisories, email
+   **agentic-coding@gsa.gov** with the subject prefixed `[SECURITY]`.
+
+Please include what you found, where (file, path, or command), and how to
+reproduce it.
+
 ## Scope
 
-This repository is part of the **Agentic Coding Capability Assessment** — an internal GSA initiative. It contains:
+This policy covers **this repository's own content and tooling**. These repos are
+**out of scope** for GSA's official Vulnerability Disclosure Policy. If your
+report concerns an actual GSA system or service (rather than this repository),
+please use GSA's Vulnerability Disclosure Policy instead:
+<https://www.gsa.gov/website-information/vulnerability-disclosure-policy>.
 
-- **Reference documentation** for secure agentic coding practices
-- **Python validation toolchain** (`scripts/playbook_validator/`)
-- **Skills and templates** for AI-assisted development
+## What to expect
 
-There are no deployed services or production infrastructure. Security concerns here relate to:
+We're a small maintainer team, and we take security reports seriously. We'll
+acknowledge your report as soon as we reasonably can, and we'll keep you posted
+as we look into it. We can't commit to a formal response timeline, but we
+genuinely appreciate you taking the time to help — thank you for making this
+project better and safer for everyone who uses it.
 
-- Incorrect or outdated standards that could lead to insecure implementations
-- Misaligned NIST control mappings that could cause compliance gaps
-- Content that contradicts authoritative federal publications
+## A note on licensing
 
-> **Note:** This repository provides informational content and best practices. It is not authoritative GSA policy or official federal guidance.
-
-## Reporting and Fixing Security Issues
-
-This is an **internal assessment repository** with trusted contributors. The appropriate response to most issues is to fix them directly.
-
-### For Content Accuracy Issues
-
-If you find content that is incorrect, outdated, or could lead to insecure implementations:
-
-1. **Submit a PR to fix it** — This is the preferred approach for internal repos
-2. **Open an issue** if you're unsure how to fix it or want to discuss first
-3. **Ask in the agentic-coding Slack channel** if you have questions or need help
-
-Please include:
-- Which document and section contains the issue
-- The specific content that is incorrect
-- The authoritative source that contradicts it (NIST publication, OMB memo, etc.)
-- Suggested correction
-
-### For Repository Infrastructure Issues
-
-If you find a security issue with the repository infrastructure (CI pipeline, GitHub Actions, dependencies, validation scripts):
-
-1. **Submit a PR to fix it** — You have access, so fix it directly when possible
-2. **Open an issue** to track the problem if you need help or it requires discussion
-3. **Contact channel admins** if you're unsure about the right approach
-
-Since this is an internal repository, formal security advisories are not required. Use your judgment — if something seems sensitive, discuss with channel admins before posting details publicly.
-
-### For GSA Platform Issues (Outside This Repo)
-
-For security concerns related to GSA systems or infrastructure outside the scope of this repository:
-
-- **Follow your normal GSA security reporting processes**
-- **Submit a ticket** or **email GSA security** as appropriate for your organization
-
-These repos are for the assessment — platform and infrastructure security follows standard GSA procedures.
-
-## Framework Version Tracking
-
-This content tracks evolving federal standards. When a referenced framework is updated (e.g., new NIST SP revision), we will:
-
-1. Create an issue tracking the update
-2. Review all affected documents
-3. Update mappings and cross-references
-4. Tag a new release with updated framework versions in CHANGELOG.md
-
-## Security Best Practices
-
-When using this repository:
-
-1. **Validate all content** — Run `make validate` before using templates
-2. **Check authoritative sources** — This content references NIST/OMB/OWASP but is not a substitute
-3. **Review agent-generated code** — AI-assisted development requires human review
-4. **Follow AGENTS.md** — The behavioral contract helps prevent unsafe agent actions
-
-## Supported Versions
-
-Security updates are applied to the current `main` branch. Check the [CHANGELOG](CHANGELOG.md) for the current version.
-
----
-
-**Last Updated:** 2026-05-21
+This project is dedicated to the public domain under
+[CC0 1.0 Universal](./LICENSE).

--- a/scripts/playbook_validator/validate_docs.py
+++ b/scripts/playbook_validator/validate_docs.py
@@ -30,6 +30,9 @@ EXCLUDED_FILENAMES = frozenset(
         "CONTRIBUTING.md",
         "CHANGELOG.md",
         "SECURITY.md",
+        "CODE_OF_CONDUCT.md",
+        "SUPPORT.md",
+        "GOVERNANCE.md",
         "LICENSE",
         "TRANSFER.md",
     }

--- a/scripts/tests/test_validate_docs.py
+++ b/scripts/tests/test_validate_docs.py
@@ -240,6 +240,19 @@ class TestFindContentFiles:
         assert "README.md" not in filenames
         assert "CONTRIBUTING.md" not in filenames
 
+    def test_excludes_community_health_files(self, tmp_path):
+        # GitHub-recognized community-health files are kept in their standard
+        # form (GitHub renders them specially) and MUST NOT require content-doc
+        # frontmatter.
+        (tmp_path / "CODE_OF_CONDUCT.md").write_text("# Code of Conduct")
+        (tmp_path / "SUPPORT.md").write_text("# Support")
+        (tmp_path / "GOVERNANCE.md").write_text("# Governance")
+        files = find_content_files(tmp_path)
+        filenames = [f.name for f in files]
+        assert "CODE_OF_CONDUCT.md" not in filenames
+        assert "SUPPORT.md" not in filenames
+        assert "GOVERNANCE.md" not in filenames
+
     def test_excludes_skills_dir(self, tmp_path):
         skills = tmp_path / "skills" / "test-skill"
         skills.mkdir(parents=True)


### PR DESCRIPTION
## Summary

Prepares the playbook for **public release**. Part of the public-readiness epic (#179); closes #174 (SECURITY), #175 (CoC). Contact is the monitored group **agentic-coding@gsa.gov**.

## Changes

- **SECURITY.md** — external-reporter rewrite: private Security Advisories first, `agentic-coding@gsa.gov` fallback, honest no-SLA tone, plain scope (docs/templates/validators; no hosted service/user data), out-of-scope→[GSA VDP](https://www.gsa.gov/website-information/vulnerability-disclosure-policy).
- **CODE_OF_CONDUCT.md** (new) — self-contained, **values-neutral** professional-conduct standard + Federal Community Addendum; `agentic-coding@gsa.gov` (`[CONDUCT]`). Self-contained because the **TTS Handbook is archived** (no live upstream to reference).
- **CONTRIBUTING.md** — canonical federal CC0 "Public domain" paragraph; link the CoC; drop "internal repository / internal repos" framing.
- **README.md** — **scope reframe (7/7 consensus)**: practical, living approach across single-agent **and** multi-agent/swarm workflows; backend + frontend + accessibility/508 + full SDLC; FIPS Moderate baseline (adapt to your ATO); explicit "**not** authoritative federal policy", not FIPS-High/classified, not procurement guidance, community-maintained/no-warranty. Removes the now-inaccurate single-agent / internal-enterprise framing.
- **validate_docs.py** (+ test) — exempt community-health files (`CODE_OF_CONDUCT.md`, `SUPPORT.md`, `GOVERNANCE.md`) from content-doc frontmatter, matching the existing README/CONTRIBUTING/SECURITY exemption.

## Verification

`validate-docs` → 0 errors; `test_validate_docs.py` → 26 passed; pre-commit (incl. ensure-contract, ruff, markdownlint, gitleaks) — all pass.

## Notes

- Values-neutral CoC + single-inbox model were explicit human decisions; scope reframe 7/7 consensus-approved.
- **Go-public dependency:** enable GitHub private Security Advisories at publication (can't pre-enable while internal) — tracked in #179.

Closes #174. Closes #175.

AI-assisted (OpenCode); consensus-reviewed. Requires human review.