### PR TITLE
docs: remove internal Slack references for public readiness (#176)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Slack Channel
-    url: https://gsa.enterprise.slack.com/archives/C0B44531QLE
-    about: For quick questions and real-time discussion, ask in the agentic-coding Slack channel
   - name: Agentic Coding Quickstart
     url: https://github.com/GSA-TTS/agentic-coding-quickstart
     about: For environment setup, SBX configuration, and getting started

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,11 +12,11 @@ This repo is one of three in the agentic coding ecosystem:
 | **[Playbook](https://github.com/GSA-TTS/agentic-coding-playbook)** (you are here) | Standards & practices | Coding standards, skills, templates |
 | **[Patterns](https://github.com/GSA-TTS/agentic-coding-patterns)** | Community sharing | Workflows, lessons learned, examples |
 
-**Not sure where your contribution belongs?** Ask in the agentic-coding Slack channel.
+**Not sure where your contribution belongs?** Open a GitHub issue to discuss.
 
 ## Getting Help
 
-- **Questions:** Ask in the agentic-coding Slack channel
+- **Questions:** Open a GitHub issue or start a discussion
 - **Bugs/improvements:** Open a GitHub issue or submit a PR
 - **Security issues:** See [SECURITY.md](SECURITY.md) — direct fixes preferred
 
@@ -26,7 +26,7 @@ The simplest approach:
 
 1. **Fix it directly** — Submit a PR
 2. **Not sure how?** — Open an issue to discuss first
-3. **Questions?** — Ask in the agentic-coding Slack channel
+3. **Questions?** — Open a GitHub issue to discuss
 
 ## Contribution Guidelines
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ agentic-coding-playbook/
 We welcome contributions from the agentic coding community.
 
 - **Fix it directly** — Submit a PR
-- **Questions** — Ask in the agentic-coding Slack channel
+- **Questions** — Open a GitHub issue or start a discussion
 - **Not sure how?** — Open an issue to discuss
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for details. This project uses [conventional commits](https://www.conventionalcommits.org/) and automated releases via [release-please](https://github.com/googleapis/release-please).


### PR DESCRIPTION
## Summary

Public-readiness blocker (epic #179, closes #176). Removes the internal GSA Slack workspace URL and "agentic-coding Slack channel" pointers from public-facing files — external contributors can't access them and they leak internal org topology.

## Changes (docs-only)

- `.github/ISSUE_TEMPLATE/config.yml` — drop the Slack `contact_link` (keep sibling-repo links)
- `README.md` — "Questions" → open a GitHub issue
- `CONTRIBUTING.md` — 3 Slack pointers → GitHub issues/discussions

## Verification

pre-commit (markdownlint, ensure-contract, gitleaks) pass; `config.yml` YAML valid; 0 residual internal-Slack references.

Closes #176.

AI-assisted (OpenCode); requires human review.