### PR TITLE
docs: add SUPPORT.md and emphasize federal community (#178)

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ agentic-coding-playbook/
 
 ## Contributing
 
-We welcome contributions from the agentic coding community.
+We welcome contributions from the federal agentic-coding community.
 
 - **Fix it directly** — Submit a PR
 - **Questions** — Ask in the agentic-coding Slack channel

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,8 @@
 
 ## About this repository
 
-The `agentic-coding-playbook` is a living, community-maintained repository that
+The `agentic-coding-playbook` is a living repository — maintained by and for the
+federal agentic-coding community — that
 captures a practical approach to implementing current federal requirements
 alongside security and software-development best practices for AI-assisted work.
 It is **not** an authoritative source of federal policy or standards. It contains

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,39 @@
+# Support
+
+The Agentic Coding Playbook is a living set of practical guidance, templates,
+and validation tooling for secure AI-assisted development, maintained by and for
+the federal agentic-coding community.
+
+## Documentation
+
+- [README](README.md) — overview and quick start
+- [docs/GETTING-STARTED.md](docs/GETTING-STARTED.md) — start here
+- [docs/](docs/) — full documentation
+
+## Questions or help
+
+Open a [GitHub issue](https://github.com/GSA-TTS/agentic-coding-playbook/issues)
+(or a Discussion, if enabled). Others benefit from the answer too.
+
+## Bugs and feature requests
+
+Open a [GitHub issue](https://github.com/GSA-TTS/agentic-coding-playbook/issues)
+with steps to reproduce (for bugs) or a clear description of the request.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Security vulnerabilities
+
+**Do not open a public issue for a security vulnerability.** See
+[SECURITY.md](SECURITY.md) for how to report one privately.
+
+## Code of conduct
+
+See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
+---
+
+This project is maintained by and for the federal agentic-coding community, and provided as-is under
+[CC0 1.0](LICENSE), on a best-effort basis (no guaranteed response time).


### PR DESCRIPTION
## Summary

Public-readiness should-fix (epic #179, part of #178). Adds a minimal SUPPORT.md and sharpens the audience framing to the **federal** community.

## Changes (docs-only)

- **SUPPORT.md** (new) — short, link-based "how to get help": README + `docs/GETTING-STARTED.md` + `docs/`; GitHub issues for questions/bugs; CONTRIBUTING for contributing; SECURITY.md for private vuln reports (not public issues); CODE_OF_CONDUCT link; best-effort/CC0 note. GitHub renders it as the Support link at issue-creation.
- **Federal-community emphasis** — SECURITY.md "About", README Contributing, and SUPPORT.md now say "maintained by and for the **federal** agentic-coding community" (these repos are tailored to the federal community) rather than a generic "community-maintained". CoC boilerplate and repo-reference uses of "community" left unchanged.

## Notes

- 3/3 consensus-approved the minimal SUPPORT.md; **GOVERNANCE.md/MAINTAINERS.md deliberately skipped** — ceremony a 2-maintainer repo doesn't need (ownership is in CODEOWNERS), matching TTS peer repos (data.gov/18F/cloud.gov don't ship them either).
- All SUPPORT.md relative links verified to resolve.

Part of #178.

AI-assisted (OpenCode); consensus-reviewed. Requires human review.