### PR TITLE
fix(contract): reconcile contract version to 1.0.0 + guard against drift (#191)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ status: canonical
 tier: 1
 contract:
   role: universal
-  version: "0.4.0"
+  version: "1.0.0"
 last_updated: "2026-07-22"
 nist_controls: ["AC-2", "AC-3", "AC-6", "AU-2", "AU-3", "AU-12", "CM-2", "CM-3", "CM-5", "CM-6", "CM-7", "CM-10", "IA-8", "IR-4", "IR-6", "PL-4", "SA-4", "SA-5", "SA-8", "SA-11", "SA-15", "SA-17", "SC-7", "SC-8", "SC-13", "SI-10", "SI-17", "SR-3"]
 frameworks: ["NIST SP 800-53 Rev 5.2", "NIST AI RMF 1.0", "NIST AI 600-1", "NCCOE Agent Identity", "OWASP Top 10 LLM 2025", "OWASP Top 10 Agentic 2026"]
@@ -20,7 +20,7 @@ review_cycle: "quarterly"
 
 # AGENTS.md — Federal AI Agent Behavioral Best Practices
 
-> **Version:** 0.3.0 | **Impact Level:** FIPS Moderate | **Scope:** Single-agent, internal enterprise
+> **Version:** 1.0.0 | **Impact Level:** FIPS Moderate | **Scope:** Single-agent, internal enterprise
 
 ## Quick Reference
 
@@ -729,6 +729,7 @@ Each section above includes inline control mappings (e.g., `> **Control Mapping:
 
 | Date | Version | Change |
 |------|---------|--------|
+| 2026-08-07 | 1.0.0 | Reconcile the contract version: the `contract.version` marker, the document banner, `config.CURRENT_CONTRACT_VERSION`, and the thin template's `requires_contract: ">=1.0"` are now all **1.0.0** (was frontmatter 0.4.0 / banner 0.3.0 / config 1.0.0 — a contradiction where 0.4.0 failed the template's `>=1.0`). No behavioral rule changed; this is a version-truth fix (#191) so downstream `requires_contract` compatibility (#153) is well-defined. |
 | 2026-07-22 | 0.4.0 | Add license-acceptance rules: §3.2 requires human approval before accepting a license/EULA on the org's behalf; §5.2 forbids auto-accepting license terms and prefers license-unencumbered equivalents (e.g. CINC over Chef InSpec); add SA-4, CM-10 mappings |
 | 2026-07-06 | 0.3.0 | Split into universal contract + thin project layer; add fail-closed contract-prerequisite probe; designate canonical via a versioned `contract:` frontmatter block (`role: universal`, `version: 1.0.0`) recognized by structure, not content |
 | 2026-06-26 | 0.2.0 | Add §8.3 periodic end-to-end validation, §9.3 discovered-defect filing gate, §14.1.1 plan proportionality + expedited mode, §15.5 track-all-work, wiring/downstream self-check items; reconcile version banner + related_files; drop hardcoded test count |

--- a/scripts/playbook_validator/validate_docs.py
+++ b/scripts/playbook_validator/validate_docs.py
@@ -232,6 +232,8 @@ def validate_contract_role(root: Path) -> tuple[list[str], list[str]]:
             )
         elif not contract_version(fm):
             errors.append(f"{universal} — universal contract MUST declare contract.{CONTRACT_VERSION_KEY}")
+        else:
+            errors.extend(_check_contract_version_consistency(universal, fm))
 
     for rel in _THIN_LAYER_PATHS:
         thin = root / rel
@@ -325,3 +327,34 @@ def validate_count_drift(root: Path) -> tuple[list[str], list[str]]:
                         )
 
     return errors, warnings
+
+
+# Body banner "> **Version:** X.Y.Z" in the universal contract — must agree with
+# the frontmatter contract.version and config.CURRENT_CONTRACT_VERSION so the
+# three copies can never drift apart again (#191).
+_BANNER_VERSION_RE = re.compile(r">\s*\*\*Version:\*\*\s*([0-9]+\.[0-9]+\.[0-9]+)")
+
+
+def _check_contract_version_consistency(universal: Path, fm: dict) -> list[str]:
+    """The universal contract's version appears in three places: the
+    ``contract.version`` frontmatter marker, the ``> **Version:**`` body banner,
+    and ``config.CURRENT_CONTRACT_VERSION``. They MUST all agree (#191) — a prior
+    drift (frontmatter 0.4.0 / banner 0.3.0 / config 1.0.0) meant the shipped
+    thin template's ``requires_contract: ">=1.0"`` was unsatisfiable."""
+    from playbook_validator.config import CURRENT_CONTRACT_VERSION
+
+    errors: list[str] = []
+    fm_version = contract_version(fm)
+    if fm_version != CURRENT_CONTRACT_VERSION:
+        errors.append(
+            f"{universal} — contract.version ({fm_version!r}) != "
+            f"config.CURRENT_CONTRACT_VERSION ({CURRENT_CONTRACT_VERSION!r}); "
+            "reconcile the two (#191)."
+        )
+    banner = _BANNER_VERSION_RE.search(universal.read_text(encoding="utf-8"))
+    if banner and banner.group(1) != fm_version:
+        errors.append(
+            f"{universal} — body banner Version ({banner.group(1)!r}) != "
+            f"contract.version ({fm_version!r}); reconcile the two (#191)."
+        )
+    return errors

--- a/scripts/tests/test_validate_docs.py
+++ b/scripts/tests/test_validate_docs.py
@@ -181,7 +181,7 @@ class TestValidateDocFrontmatter:
 class TestValidateContractRole:
     """Repository-level canonical-designation invariant (#151)."""
 
-    def _write(self, path, role=None, version=None):
+    def _write(self, path, role=None, version=None, banner=None):
         lines = ["---", 'title: "x"', 'description: "d"', "status: canonical", "tier: 1"]
         if role is not None:
             lines.append("contract:")
@@ -189,13 +189,15 @@ class TestValidateContractRole:
             if version is not None:
                 lines.append(f'  version: "{version}"')
         lines += ["---", "# body"]
+        if banner is not None:
+            lines.append(f"> **Version:** {banner} | **Impact Level:** FIPS Moderate")
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("\n".join(lines) + "\n")
 
     def test_universal_and_thin_layers_valid(self, tmp_path):
         from playbook_validator.validate_docs import validate_contract_role
 
-        self._write(tmp_path / "AGENTS.md", role="universal", version="1.0.0")
+        self._write(tmp_path / "AGENTS.md", role="universal", version="1.0.0", banner="1.0.0")
         self._write(tmp_path / "templates/AGENTS.md.template", role="project-layer")
         self._write(tmp_path / "examples/AGENTS.md.example", role="project-layer")
         errors, _ = validate_contract_role(tmp_path)
@@ -211,10 +213,56 @@ class TestValidateContractRole:
     def test_thin_layer_claiming_universal_errors(self, tmp_path):
         from playbook_validator.validate_docs import validate_contract_role
 
-        self._write(tmp_path / "AGENTS.md", role="universal", version="1.0.0")
+        self._write(tmp_path / "AGENTS.md", role="universal", version="1.0.0", banner="1.0.0")
         self._write(tmp_path / "templates/AGENTS.md.template", role="universal", version="1.0.0")
         errors, _ = validate_contract_role(tmp_path)
         assert any("thin project layer MUST NOT declare" in e for e in errors)
+
+    def test_frontmatter_version_mismatch_config_errors(self, tmp_path):
+        """#191: contract.version must equal config.CURRENT_CONTRACT_VERSION."""
+        from playbook_validator.validate_docs import validate_contract_role
+
+        self._write(tmp_path / "AGENTS.md", role="universal", version="0.4.0", banner="0.4.0")
+        errors, _ = validate_contract_role(tmp_path)
+        assert any("CURRENT_CONTRACT_VERSION" in e and "#191" in e for e in errors)
+
+    def test_banner_version_mismatch_frontmatter_errors(self, tmp_path):
+        """#191: the body banner Version must equal contract.version."""
+        from playbook_validator.config import CURRENT_CONTRACT_VERSION
+        from playbook_validator.validate_docs import validate_contract_role
+
+        self._write(
+            tmp_path / "AGENTS.md",
+            role="universal",
+            version=CURRENT_CONTRACT_VERSION,
+            banner="0.3.0",
+        )
+        errors, _ = validate_contract_role(tmp_path)
+        assert any("body banner Version" in e and "#191" in e for e in errors)
+
+    def test_version_consistent_passes(self, tmp_path):
+        """All three version copies agree → no error."""
+        from playbook_validator.config import CURRENT_CONTRACT_VERSION
+        from playbook_validator.validate_docs import validate_contract_role
+
+        self._write(
+            tmp_path / "AGENTS.md",
+            role="universal",
+            version=CURRENT_CONTRACT_VERSION,
+            banner=CURRENT_CONTRACT_VERSION,
+        )
+        errors, _ = validate_contract_role(tmp_path)
+        assert errors == []
+
+    def test_real_repo_contract_version_consistent(self):
+        """The live AGENTS.md must have frontmatter == banner == config version."""
+        from pathlib import Path
+
+        from playbook_validator.validate_docs import validate_contract_role
+
+        root = Path(__file__).resolve().parents[2]
+        errors, _ = validate_contract_role(root)
+        assert errors == [], f"live contract-version drift: {errors}"
 
 
 class TestFindContentFiles:


### PR DESCRIPTION
## Summary

Closes #191. The universal contract's version was contradicted in four places:

| Location | Was | Now |
|----------|-----|-----|
| `AGENTS.md` frontmatter `contract.version` | `0.4.0` | **`1.0.0`** |
| `AGENTS.md` body banner `> **Version:**` | `0.3.0` | **`1.0.0`** |
| `config.CURRENT_CONTRACT_VERSION` | `1.0.0` | `1.0.0` (unchanged) |
| template `requires_contract` | `>=1.0` | `>=1.0` (unchanged) |

`0.4.0` did **not** satisfy the template's own `>=1.0`, so enforcing `requires_contract` compatibility (#153) would have judged the shipped template incompatible with the shipped contract. Per maintainer decision, **1.0.0 is canonical** (the universal/project-layer split was the 1.0 milestone; config + template already assumed it). This aligns the two stale copies to `1.0.0` and adds a changelog row. **No behavioral rule changed — version-truth only.**

## Guard against recurrence (epic #183: guard, don't hardcode)

`validate_contract_role` now asserts the three version copies agree:
`contract.version` == `config.CURRENT_CONTRACT_VERSION` == the `> **Version:**` body banner. Drift fails CI.

## Verification

| Check | Result |
|-------|--------|
| `pytest scripts/tests/` | **436 pass** (4 new: frontmatter/config mismatch, banner/frontmatter mismatch, consistent-passes, live-repo consistency) |
| `validate-docs` | All validations passed |
| `generate-index --check` | up to date |
| `ruff check scripts/` | clean |

Adversarially checked the banner regex: matches only `X.Y.Z` after the exact `**Version:**` label; ignores `**Control Mapping:**` decoys, two-part versions, prose "version 1.0.0", and a banner-absent file (skips cleanly, no false error).

## Rollback

Revert the PR. Doc version strings + one validator guard + tests; no runtime/auth/data surface.

## Security Impact

None functional. Makes the contract-compatibility substrate well-defined so #153 (a security-relevant gate) can be built on a consistent version. Unblocks #153.

AI-assisted (OpenCode). Requires human review.
