### PR TITLE
feat(contract): enforce requires_contract version compatibility (#153)

### DIFF
--- a/scripts/playbook_validator/config.py
+++ b/scripts/playbook_validator/config.py
@@ -81,6 +81,73 @@ def contract_version(frontmatter: dict) -> str | None:
     return version if isinstance(version, str) else None
 
 
+def contract_requires(frontmatter: dict) -> str | None:
+    """Return ``contract.requires_contract`` from parsed frontmatter, or None.
+
+    The range a project layer declares for which universal-contract versions it
+    is compatible with (#153). See ``version_satisfies`` for the grammar."""
+    req = contract_block(frontmatter).get(CONTRACT_REQUIRES_KEY)
+    return req if isinstance(req, str) else None
+
+
+# ── Contract version-range compatibility (#153) ──────────────────────
+#
+# A deliberately tiny, dependency-free semver comparator so the SAME logic can be
+# copied verbatim into the self-contained downstream probe (templates/
+# ensure-contract.py) — no `packaging`/`semver` import allowed there. Grammar
+# supported for `requires_contract`:
+#   ">=X.Y[.Z]"  ">X.Y[.Z]"  "<=..."  "<..."  "==X.Y[.Z]" / "=X.Y[.Z]"
+#   "^X.Y[.Z]"   (caret: same major, >= the given minor.patch; major 0 pins minor)
+#   "X.Y[.Z]"    (bare == exact)
+# Missing patch defaults to 0. Anything unparseable returns False (fail-closed).
+
+_VERSION_RE = re.compile(r"^\s*(\d+)\.(\d+)(?:\.(\d+))?\s*$")
+_RANGE_RE = re.compile(r"^\s*(>=|<=|>|<|==|=|\^)?\s*(\d+)\.(\d+)(?:\.(\d+))?\s*$")
+
+
+def _parse_version(text: str) -> tuple[int, int, int] | None:
+    m = _VERSION_RE.match(text or "")
+    if not m:
+        return None
+    return int(m.group(1)), int(m.group(2)), int(m.group(3) or 0)
+
+
+def version_satisfies(version: str | None, requirement: str | None) -> bool:
+    """True if concrete ``version`` satisfies the ``requirement`` range (#153).
+
+    Fail-closed: a missing/malformed version or requirement returns False, so a
+    project can never be silently judged compatible with an unparseable pin.
+    """
+    ver = _parse_version(version or "")
+    if ver is None:
+        return False
+    m = _RANGE_RE.match(requirement or "")
+    if m is None:
+        return False
+    op = m.group(1) or "=="
+    req = (int(m.group(2)), int(m.group(3)), int(m.group(4) or 0))
+    if op in ("==", "="):
+        return ver == req
+    if op == ">=":
+        return ver >= req
+    if op == ">":
+        return ver > req
+    if op == "<=":
+        return ver <= req
+    if op == "<":
+        return ver < req
+    if op == "^":
+        # caret: same leading non-zero component; >= the given tuple.
+        if ver < req:
+            return False
+        if req[0] != 0:
+            return ver[0] == req[0]
+        if req[1] != 0:
+            return ver[0] == 0 and ver[1] == req[1]
+        return ver[0] == 0 and ver[1] == 0
+    return False
+
+
 # ── ADR (Decision Record) Schema ─────────────────────────────────────
 
 REQUIRED_ADR_FIELDS = frozenset({"title", "status", "date", "nist_controls"})

--- a/scripts/playbook_validator/ensure_contract.py
+++ b/scripts/playbook_validator/ensure_contract.py
@@ -45,7 +45,13 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
 
-from playbook_validator.config import CONTRACT_ROLE_UNIVERSAL, contract_role
+from playbook_validator.config import (
+    CONTRACT_ROLE_UNIVERSAL,
+    contract_requires,
+    contract_role,
+    contract_version,
+    version_satisfies,
+)
 from playbook_validator.frontmatter import extract_frontmatter, parse_frontmatter
 
 # ── Convention constants (single source of truth) ───────────────────────────
@@ -146,6 +152,59 @@ def _is_playbook_contract(path: Path) -> bool:
         return False
 
 
+def _text_version(text: str) -> str | None:
+    """The ``contract.version`` declared in raw Markdown ``text``, if any."""
+    return contract_version(parse_frontmatter(text))
+
+
+def _project_requires(repo_root: Path) -> str | None:
+    """The ``contract.requires_contract`` range the working project's own thin
+    AGENTS.md declares, if any. None when there is no project layer or no range.
+
+    This is the downstream project's compatibility demand against the universal
+    contract; ``ensure_contract`` checks the resolved contract's version against
+    it (#153)."""
+    project_agents = repo_root / CONTRACT_FILENAME
+    if not _is_present(project_agents):
+        return None
+    try:
+        fm = extract_frontmatter(project_agents)
+    except OSError:
+        return None
+    # Only a project-layer declares a requirement; the universal contract's own
+    # AGENTS.md (self-host case) has no requires_contract.
+    if contract_role(fm) == CONTRACT_ROLE_UNIVERSAL:
+        return None
+    return contract_requires(fm)
+
+
+def _compat_warning(repo_root: Path, contract_text: str | None) -> str | None:
+    """If the project declares ``requires_contract`` and the resolved contract's
+    version does NOT satisfy it, return an advisory string; else None (#153).
+
+    Advisory (warning, not a hard halt): the contract IS available — this only
+    flags a version-range mismatch the human should reconcile. Fail-closed
+    within its own scope: an unparseable version/range counts as unsatisfied."""
+    requirement = _project_requires(repo_root)
+    if requirement is None:
+        return None
+    available = _text_version(contract_text) if contract_text else None
+    if version_satisfies(available, requirement):
+        return None
+    return (
+        f"Contract version mismatch: this project requires "
+        f"'{requirement}' but the available universal contract is version "
+        f"{available or 'unknown'}. Update the contract or the project's "
+        "contract.requires_contract range (#153)."
+    )
+
+
+def _merge_warnings(*warnings: str | None) -> str | None:
+    """Join the non-empty warnings with a space, or None if all are empty."""
+    present = [w for w in warnings if w]
+    return " ".join(present) if present else None
+
+
 def _read_stamp_tag(stamp_path: Path) -> str | None:
     """Return the ``release_tag`` recorded in the cache stamp, if any."""
     if not stamp_path.is_file():
@@ -220,11 +279,16 @@ def ensure_contract(repo_root: Path, *, allow_fetch: bool = True) -> ContractRes
     # 1. Environment-provided home contract short-circuits everything.
     home_path = _home_contract_path()
     if _is_present(home_path):
+        try:
+            home_text = home_path.read_text(encoding="utf-8")
+        except OSError:
+            home_text = None
         return ContractResult(
             status=ContractStatus.HOME,
             ok=True,
             path=home_path,
             message=f"Universal contract present at {home_path}.",
+            warning=_compat_warning(repo_root, home_text),
         )
 
     cache_path = repo_root / CACHE_RELPATH
@@ -240,12 +304,16 @@ def ensure_contract(repo_root: Path, *, allow_fetch: bool = True) -> ContractRes
     # 2. Fresh cache (present and matching the pinned release tag).
     if _is_present(cache_path):
         if _read_stamp_tag(stamp_path) == PINNED_RELEASE_TAG:
+            try:
+                cache_text = cache_path.read_text(encoding="utf-8")
+            except OSError:
+                cache_text = None
             return ContractResult(
                 status=ContractStatus.CACHE_FRESH,
                 ok=True,
                 path=cache_path,
                 message=f"Universal contract present in cache ({cache_path}).",
-                warning=stale_warning,
+                warning=_merge_warnings(stale_warning, _compat_warning(repo_root, cache_text)),
             )
         # Cache exists but is behind the pinned release → try to refresh.
         if not allow_fetch:

--- a/scripts/tests/test_config.py
+++ b/scripts/tests/test_config.py
@@ -82,3 +82,61 @@ class TestValidators:
         assert is_valid_skill_name("-leading-hyphen") is False
         assert is_valid_skill_name("trailing-hyphen-") is False
         assert is_valid_skill_name("a" * 65) is False  # too long
+
+
+class TestVersionSatisfies:
+    """Dependency-free contract version-range comparator (#153)."""
+
+    def _vs(self):
+        from playbook_validator.config import version_satisfies
+
+        return version_satisfies
+
+    def test_gte_range(self):
+        vs = self._vs()
+        assert vs("1.0.0", ">=1.0") is True
+        assert vs("0.4.0", ">=1.0") is False  # the #191 case
+        assert vs("1.0.0", ">=1.0.0") is True
+
+    def test_gt_lt_lte(self):
+        vs = self._vs()
+        assert vs("1.2.0", ">1.0") is True
+        assert vs("1.0.0", ">1.0") is False
+        assert vs("1.0.0", "<=1.0") is True
+        assert vs("0.9.0", "<1.0") is True
+        assert vs("1.0.0", "<1.0") is False
+
+    def test_exact(self):
+        vs = self._vs()
+        assert vs("1.0.0", "==1.0.0") is True
+        assert vs("1.0.1", "==1.0.0") is False
+        assert vs("1.0.0", "=1.0") is True
+        assert vs("1.0.0", "1.0") is True  # bare == exact
+        assert vs("1.0.1", "1.0.0") is False
+
+    def test_caret(self):
+        vs = self._vs()
+        assert vs("1.5.0", "^1.0") is True
+        assert vs("2.0.0", "^1.0") is False
+        assert vs("1.0.0", "^1.2") is False  # below the floor
+        # major 0 pins the minor
+        assert vs("0.4.9", "^0.4") is True
+        assert vs("0.5.0", "^0.4") is False
+
+    def test_missing_patch_defaults_zero(self):
+        vs = self._vs()
+        assert vs("1.0", "1.0.0") is True
+        assert vs("1.0.0", "1.0") is True
+
+    def test_fail_closed_on_bad_input(self):
+        vs = self._vs()
+        assert vs(None, ">=1.0") is False
+        assert vs("1.0.0", None) is False
+        assert vs("1.0.0", "garbage") is False
+        assert vs("not-a-version", ">=1.0") is False
+        assert vs("", "") is False
+
+    def test_whitespace_tolerant(self):
+        vs = self._vs()
+        assert vs("1.0.0", ">= 1.0") is True
+        assert vs(" 1.0.0 ", ">=1.0") is True

--- a/scripts/tests/test_ensure_contract.py
+++ b/scripts/tests/test_ensure_contract.py
@@ -341,3 +341,108 @@ def test_copied_probe_accepts_universal_contract(repo, tmp_path):
     empty_home = tmp_path / "copied-empty-home2"
     empty_home.mkdir()
     assert _run_copied_probe(repo, empty_home) == 0
+
+
+# ── 10. requires_contract version-range compatibility (#153) ──────────────────
+
+import importlib.util  # noqa: E402
+
+
+def _load_copied_probe():
+    """Import templates/ensure-contract.py as a module to unit-test its
+    dependency-free helpers directly."""
+    spec = importlib.util.spec_from_file_location(
+        "copied_ensure_contract_153", PLAYBOOK_ROOT / "templates" / "ensure-contract.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_project_layer(repo: Path, requires: str | None) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    fm = "---\ntitle: p\ndescription: d\nstatus: canonical\ntier: 3\ncontract:\n  role: project-layer\n"
+    if requires is not None:
+        fm += f'  requires_contract: "{requires}"\n'
+    fm += "---\n# Project layer\n"
+    (repo / "AGENTS.md").write_text(fm)
+
+
+def _write_home_contract(home_dir: Path, version: str) -> Path:
+    home = home_dir / ".agentic-coding-playbook"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "AGENTS.md").write_text(
+        f'---\ntitle: u\ncontract:\n  role: universal\n  version: "{version}"\n---\n'
+        "# AGENTS.md — Federal AI Agent Behavioral Best Practices\n"
+    )
+    return home
+
+
+def test_requires_satisfied_no_warning(repo, tmp_path, monkeypatch):
+    """Project requires >=1.0, home contract is 1.0.0 → ok, no compat warning."""
+    _write_project_layer(repo, ">=1.0")
+    home = _write_home_contract(tmp_path / "h1", "1.0.0")
+    monkeypatch.setenv(ec.HOME_OVERRIDE_ENV, str(home))
+    result = ensure_contract(repo, allow_fetch=False)
+    assert result.ok is True
+    assert result.status == ContractStatus.HOME
+    assert result.warning is None
+
+
+def test_requires_unsatisfied_warns_but_ok(repo, tmp_path, monkeypatch):
+    """Project requires >=1.0, home contract is 0.4.0 → ok (present) BUT a
+    compat warning fires (the #153 signal; #191 was exactly this drift)."""
+    _write_project_layer(repo, ">=1.0")
+    home = _write_home_contract(tmp_path / "h2", "0.4.0")
+    monkeypatch.setenv(ec.HOME_OVERRIDE_ENV, str(home))
+    result = ensure_contract(repo, allow_fetch=False)
+    assert result.ok is True
+    assert result.warning and "requires" in result.warning and "0.4.0" in result.warning
+
+
+def test_no_requires_no_warning(repo, tmp_path, monkeypatch):
+    """A project with no requires_contract never gets a compat warning."""
+    _write_project_layer(repo, None)
+    home = _write_home_contract(tmp_path / "h3", "0.4.0")
+    monkeypatch.setenv(ec.HOME_OVERRIDE_ENV, str(home))
+    result = ensure_contract(repo, allow_fetch=False)
+    assert result.ok is True
+    assert result.warning is None
+
+
+def test_caret_range_unsatisfied_warns(repo, tmp_path, monkeypatch):
+    """Caret range enforced: requires ^1.0, contract 2.0.0 → warning."""
+    _write_project_layer(repo, "^1.0")
+    home = _write_home_contract(tmp_path / "h4", "2.0.0")
+    monkeypatch.setenv(ec.HOME_OVERRIDE_ENV, str(home))
+    result = ensure_contract(repo, allow_fetch=False)
+    assert result.warning and "^1.0" in result.warning
+
+
+def test_comparator_parity_module_vs_copied():
+    """#153/#154: the copied probe's _version_satisfies MUST return the same
+    verdict as the module config.version_satisfies for every combination —
+    they are duplicated (copied probe is dependency-free) and must not drift."""
+    import itertools
+
+    from playbook_validator.config import version_satisfies as module_vs
+
+    copied = _load_copied_probe()
+    versions = [None, "", "1.0.0", "0.4.0", "1.0", "1.2.3", "2.0.0", "0.5.0", "bad"]
+    ranges = [
+        None,
+        "",
+        ">=1.0",
+        ">1.0",
+        "<=1.0",
+        "<1.0",
+        "==1.0.0",
+        "=1.0",
+        "^1.0",
+        "^0.4",
+        "1.0.0",
+        "garbage",
+        ">= 1.0",
+    ]
+    for v, r in itertools.product(versions, ranges):
+        assert copied._version_satisfies(v, r) == module_vs(v, r), f"comparator divergence on ({v!r}, {r!r})"

--- a/templates/ensure-contract.py
+++ b/templates/ensure-contract.py
@@ -42,7 +42,7 @@ import os
 import sys
 import urllib.error
 import urllib.request
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 DEFAULT_HOME = Path.home() / ".agentic-coding-playbook"
@@ -59,6 +59,8 @@ STAMP_RELPATH = Path(".agents/cache/AGENTS.universal.stamp")
 CONTRACT_FIELD = "contract"
 CONTRACT_ROLE_KEY = "role"
 CONTRACT_ROLE_UNIVERSAL = "universal"
+CONTRACT_VERSION_KEY = "version"
+CONTRACT_REQUIRES_KEY = "requires_contract"
 
 # Pinned release the cache is fetched from and measured against. Hard-coded.
 PINNED_RELEASE_TAG = "v0.13.0"
@@ -132,6 +134,117 @@ def _is_playbook_contract(path: Path) -> bool:
         return False
 
 
+def _contract_child_value(text: str, child_key: str) -> str | None:
+    """Return the value of ``contract.<child_key>`` from raw frontmatter, or None.
+
+    Dependency-free block scan (same indentation approach as
+    ``_text_declares_universal``). Reads simple scalar children like ``version``
+    and ``requires_contract``. Sufficient for the single-level contract marker;
+    values are simple scalars, never nested."""
+    if not text.startswith("---"):
+        return None
+    end = text.find("\n---", 3)
+    if end == -1:
+        return None
+    in_contract = False
+    contract_indent = 0
+    for raw_line in text[4:end].splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip())
+        stripped = raw_line.strip()
+        if not in_contract:
+            if stripped.rstrip() == f"{CONTRACT_FIELD}:":
+                in_contract = True
+                contract_indent = indent
+            continue
+        if indent <= contract_indent:
+            in_contract = False
+            if stripped.rstrip() == f"{CONTRACT_FIELD}:":
+                in_contract = True
+                contract_indent = indent
+            continue
+        key, sep, value = stripped.partition(":")
+        if sep and key.strip() == child_key:
+            return value.strip().strip("\"'") or None
+    return None
+
+
+# ── Version-range compatibility (#153) — MUST mirror config.version_satisfies ──
+# Dependency-free copy of the playbook's config.version_satisfies. Keep the two
+# in sync (the playbook is source of truth); a cross-probe parity test guards it.
+import re as _re  # noqa: E402  (local import to keep the stdlib header block intact)
+
+_VERSION_RE = _re.compile(r"^\s*(\d+)\.(\d+)(?:\.(\d+))?\s*$")
+_RANGE_RE = _re.compile(r"^\s*(>=|<=|>|<|==|=|\^)?\s*(\d+)\.(\d+)(?:\.(\d+))?\s*$")
+
+
+def _parse_version(text: str):
+    m = _VERSION_RE.match(text or "")
+    if not m:
+        return None
+    return int(m.group(1)), int(m.group(2)), int(m.group(3) or 0)
+
+
+def _version_satisfies(version, requirement) -> bool:
+    """True if ``version`` satisfies the ``requirement`` range. Fail-closed on a
+    missing/malformed version or range. Mirrors config.version_satisfies (#153)."""
+    ver = _parse_version(version or "")
+    if ver is None:
+        return False
+    m = _RANGE_RE.match(requirement or "")
+    if m is None:
+        return False
+    op = m.group(1) or "=="
+    req = (int(m.group(2)), int(m.group(3)), int(m.group(4) or 0))
+    if op in ("==", "="):
+        return ver == req
+    if op == ">=":
+        return ver >= req
+    if op == ">":
+        return ver > req
+    if op == "<=":
+        return ver <= req
+    if op == "<":
+        return ver < req
+    if op == "^":
+        if ver < req:
+            return False
+        if req[0] != 0:
+            return ver[0] == req[0]
+        if req[1] != 0:
+            return ver[0] == 0 and ver[1] == req[1]
+        return ver[0] == 0 and ver[1] == 0
+    return False
+
+
+def _compat_warning(repo_root: Path, contract_text: str | None) -> str | None:
+    """If the project's own AGENTS.md declares ``contract.requires_contract`` and
+    the available contract's ``contract.version`` does NOT satisfy it, return an
+    advisory string; else None. Advisory, not a hard halt (#153)."""
+    project = repo_root / CONTRACT_FILENAME
+    if not _is_present(project):
+        return None
+    try:
+        project_text = project.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    if _text_declares_universal(project_text):  # the universal contract itself
+        return None
+    requirement = _contract_child_value(project_text, CONTRACT_REQUIRES_KEY)
+    if requirement is None:
+        return None
+    available = _contract_child_value(contract_text, CONTRACT_VERSION_KEY) if contract_text else None
+    if _version_satisfies(available, requirement):
+        return None
+    return (
+        f"WARNING: contract version mismatch — this project requires "
+        f"'{requirement}' but the available universal contract is version "
+        f"{available or 'unknown'}. Update the contract or the project's "
+        "contract.requires_contract range (#153)."
+    )
+
+
 def _read_stamp_tag(stamp_path: Path) -> str | None:
     if not stamp_path.is_file():
         return None
@@ -149,9 +262,7 @@ def _write_cache(cache_path: Path, stamp_path: Path, content: str) -> None:
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     cache_path.write_text(content, encoding="utf-8")
     stamp = (
-        f"source_url={CONTRACT_RAW_URL}\n"
-        f"release_tag={PINNED_RELEASE_TAG}\n"
-        f"fetched_at={datetime.now(timezone.utc).isoformat()}\n"
+        f"source_url={CONTRACT_RAW_URL}\nrelease_tag={PINNED_RELEASE_TAG}\nfetched_at={datetime.now(UTC).isoformat()}\n"
     )
     stamp_path.write_text(stamp, encoding="utf-8")
 
@@ -186,6 +297,13 @@ def ensure_contract(repo_root: Path, *, allow_fetch: bool = True) -> int:
 
     home_path = _home_contract_path()
     if _is_present(home_path):
+        try:
+            home_text = home_path.read_text(encoding="utf-8")
+        except OSError:
+            home_text = None
+        compat = _compat_warning(repo_root, home_text)
+        if compat:
+            print(compat, file=sys.stderr)
         print(f"present-home: universal contract at {home_path}")
         return 0
 
@@ -201,6 +319,13 @@ def ensure_contract(repo_root: Path, *, allow_fetch: bool = True) -> int:
     if _is_present(cache_path):
         if _read_stamp_tag(stamp_path) == PINNED_RELEASE_TAG:
             print(warn, file=sys.stderr)
+            try:
+                cache_text = cache_path.read_text(encoding="utf-8")
+            except OSError:
+                cache_text = None
+            compat = _compat_warning(repo_root, cache_text)
+            if compat:
+                print(compat, file=sys.stderr)
             print(f"present-cache-fresh: universal contract in cache ({cache_path})")
             return 0
         if not allow_fetch:


### PR DESCRIPTION
## Summary

Closes #153. **Stacked on #192 (#191)** — review/merge #192 first; this PR's base is `fix/contract-version-1.0-191`, so its own diff is only the #153 changes.

A project layer's `contract.requires_contract` range was parsed by **neither** probe and compared against **nothing**. A project declaring `requires_contract: ">=1.0"` got no signal when the available universal contract was an older version — which is exactly why the #191 drift (contract `0.4.0` vs template `>=1.0`) sat undetected.

## Change

- **`config.py`** — `contract_requires()` + a **dependency-free** semver-range comparator `version_satisfies()`: supports `>= > <= < == = ^` and bare-exact, missing-patch defaults to 0, **fail-closed** on any malformed version/range.
- **`ensure_contract.py`** (module probe) — when the working project's own AGENTS.md declares `requires_contract` and the resolved contract's `contract.version` does **not** satisfy it, attach an **advisory warning**. The contract is still present, so `ok` stays true — this is a compatibility signal, not a hard halt (a mismatched-but-present contract shouldn't block work; the human reconciles the range).
- **`templates/ensure-contract.py`** (copied dep-free probe) — mirror the comparator and the compat check stdlib-only, so downstream projects get the same signal without installing `playbook-validator`.

## Why two comparators (and how they can't drift)

The copied probe must stay dependency-free (no `packaging`/`semver`), so the comparator is necessarily duplicated. A **parity test asserts the two implementations agree across all 117 (version, range) combinations** — the same divergence-class guard that #154 established for the recognizer.

## Verification

| Check | Result |
|-------|--------|
| `pytest scripts/tests/` | **448 pass** (new: `TestVersionSatisfies`; requires satisfied/unsatisfied/no-req/caret; **comparator parity 117 combos**) |
| `validate-docs` | All validations passed |
| `ruff check scripts/` | clean |
| module-probe e2e | requires `>=1.0` + contract `0.4.0` → warns; + `1.0.0` → clean; no-req → clean; `^1.0` + `2.0.0` → warns |

## Design choice for reviewer

Compatibility mismatch is **advisory (warning), not fail-closed halt**. Rationale: the contract IS available; a version-range mismatch is a "reconcile your range / update the contract" signal, not an availability failure — halting would block all downstream work on a version quibble. If you'd prefer it to hard-fail (exit non-zero) when a range is declared and unmet, say so and I'll gate it behind a flag (default advisory).

## Rollback

Revert. Adds a comparator + two advisory call-sites + tests; no behavior removed, no network/auth/data surface change.

## Security Impact

Strengthens the contract-prerequisite gate (ADR-0003): a project can now detect it's running against an incompatible contract version. Fail-closed comparator (malformed → unsatisfied) means a bad pin never silently reads as "compatible".

AI-assisted (OpenCode). Requires human review.
