### PR TITLE
fix(ci): bump js-yaml override to 4.3.1 in linters (CVE-2026-59870)

### DIFF
--- a/.github/linters/package-lock.json
+++ b/.github/linters/package-lock.json
@@ -395,9 +395,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -408,6 +408,7 @@
           "url": "https://github.com/sponsors/nodeca"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/.github/linters/package.json
+++ b/.github/linters/package.json
@@ -10,7 +10,7 @@
     "markdownlint-cli2": "0.22.1"
   },
   "overrides": {
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "markdown-it": "14.3.0"
   }
 }


### PR DESCRIPTION
## Summary

Every open PR's **Python Lint, Test & Validate** check is red — and so is `main`. Root cause is **not** any PR's code: the CI `Install linter dependencies` step runs `npm audit --audit-level=high`, which now fails on **GHSA-5p4m-2wfm-xmqj** (js-yaml quadratic CPU in `!!omap`, CVE-2026-59870) reaching the pinned `markdownlint-cli2` via a transitive `js-yaml 4.3.0`.

## Fix

Bump the `js-yaml` override `4.3.0 → 4.3.1` (the patched release) in `.github/linters/package.json` + lockfile. Mirrors the fix already shipped in **agentic-coding-patterns #298**. Avoids the `markdownlint-cli2` breaking major that `npm audit fix --force` would apply.

## Verification
- `npm ci && npm audit --audit-level=high` → **found 0 vulnerabilities**
- `js-yaml` runtime resolves to **4.3.1**
- `markdownlint-cli2` still runs clean (0 errors on the repo)

## Impact
This unblocks the red check on PRs #188, #190, #192, #193 (a shared CI/env failure, not their code) and greens `main`. **Merge this first**, then those PRs go green on rebase.

## Security Impact
Removes a high-severity DoS advisory from the CI toolchain (SR-3 supply chain). No runtime/app surface.

AI-assisted (OpenCode). Requires human review.