### PR TITLE
fix(landscape): scope Federal Register query + source-aware relevance gate (#182)

### DIFF
--- a/scripts/landscape_monitor.py
+++ b/scripts/landscape_monitor.py
@@ -42,19 +42,53 @@ RSS_FEEDS = [
     },
     {
         "name": "Federal Register - AI",
-        "url": "https://www.federalregister.gov/api/v1/documents.rss?conditions%5Bterm%5D=artificial+intelligence",
+        # Scoped query (#182): restrict to the document types that carry AI
+        # governance (presidential documents, rules, proposed rules, notices)
+        # rather than an unscoped free-text term match that also returns grant
+        # notices, meeting announcements, and export bulletins. `per_page`
+        # bounds the response; `order=newest` keeps the most recent first.
+        "url": (
+            "https://www.federalregister.gov/api/v1/documents.rss"
+            "?conditions%5Bterm%5D=artificial+intelligence"
+            "&conditions%5Btype%5D%5B%5D=PRESDOCU"
+            "&conditions%5Btype%5D%5B%5D=RULE"
+            "&conditions%5Btype%5D%5B%5D=PRORULE"
+            "&conditions%5Btype%5D%5B%5D=NOTICE"
+            "&order=newest&per_page=50"
+        ),
         "category_hint": "legislation",
     },
 ]
 
-# Keywords that indicate AI-related content
+# Strong AI-governance signal (#182). A single loose token like a bare "AI",
+# "ML", or "algorithm" is NOT enough on its own — those matched grant notices,
+# committee announcements, and unrelated rules. An item is surfaced only if its
+# title+summary matches one of these specific phrases. (A bare-token secondary
+# pass is applied ONLY to feeds already scoped to an AI/NIST source; see
+# `_is_ai_relevant`.)
 AI_KEYWORDS = re.compile(
-    r"\b(artificial intelligence|AI|machine learning|ML|"
-    r"large language model|LLM|generative AI|foundation model|"
-    r"neural network|deep learning|algorithm|automated decision|"
-    r"NIST AI|AI RMF|agentic)\b",
+    r"\b("
+    r"artificial intelligence|"
+    r"machine learning|"
+    r"large language model|LLM|"
+    r"generative AI|gen(?:erative)?\s?AI|"
+    r"foundation model|frontier model|"
+    r"neural network|deep learning|"
+    r"automated decision|automated decision-?making|"
+    r"NIST AI|AI RMF|AI risk management|"
+    r"agentic|AI safety|AI governance|"
+    r"algorithmic (?:accountability|impact|bias)"
+    r")\b",
     re.IGNORECASE,
 )
+
+# Weak tokens that only count when the feed is ALREADY AI/NIST-scoped by source
+# (e.g. the NIST CSRC feed). On the broad Federal Register feed a bare "AI"/"ML"
+# is too noisy to surface on its own.
+_WEAK_AI_TOKENS = re.compile(r"\b(AI|ML|algorithm)\b")
+# Feeds whose SOURCE already narrows the topic — the weak token pass is allowed
+# for these because the surrounding corpus is on-topic.
+_SOURCE_SCOPED_FEEDS = frozenset({"NIST CSRC"})
 
 # How far back to look in RSS feeds (days)
 LOOKBACK_DAYS = 90
@@ -152,6 +186,19 @@ def load_registry(path: Path) -> tuple[list[RegistryEntry], dict[str, RegistryEn
 # ─────────────────────────────────────────────────────────────────────────────
 
 
+def _is_ai_relevant(text: str, source: str) -> bool:
+    """True if ``text`` (title+summary) is AI-governance relevant for ``source``.
+
+    Precision gate for #182: a strong-phrase match always qualifies. A weak bare
+    token ("AI"/"ML"/"algorithm") qualifies ONLY when the feed source is already
+    topic-scoped (e.g. NIST CSRC), so the broad Federal Register feed no longer
+    surfaces grant notices / meeting announcements that merely contain "AI".
+    """
+    if AI_KEYWORDS.search(text):
+        return True
+    return source in _SOURCE_SCOPED_FEEDS and bool(_WEAK_AI_TOKENS.search(text))
+
+
 def fetch_rss_feeds(feeds: list[dict[str, str]]) -> list[RSSEntry]:
     """Fetch and parse RSS feeds, filtering for AI-related content."""
     if not FEEDPARSER_AVAILABLE:
@@ -184,9 +231,9 @@ def fetch_rss_feeds(feeds: list[dict[str, str]]) -> list[RSSEntry]:
                 summary = getattr(item, "summary", "")
                 link = getattr(item, "link", "")
 
-                # Filter for AI-related content
+                # Filter for AI-related content (source-aware precision, #182)
                 text_to_check = f"{title} {summary}"
-                if not AI_KEYWORDS.search(text_to_check):
+                if not _is_ai_relevant(text_to_check, feed_config["name"]):
                     continue
 
                 entries.append(

--- a/scripts/tests/test_landscape_monitor.py
+++ b/scripts/tests/test_landscape_monitor.py
@@ -1,0 +1,203 @@
+"""Tests for the federal-AI landscape RSS monitor.
+
+Covers the #182 precision work (source-aware relevance gate + scoped Federal
+Register query) and the previously-untested diff/relevance logic. Network is
+never hit: feedparser.parse is mocked and RSS_FEEDS is patched.
+"""
+
+from datetime import datetime, timedelta
+from unittest import mock
+
+import landscape_monitor as lm
+import pytest
+
+# ── Relevance gate (#182) ─────────────────────────────────────────────────────
+
+
+class TestIsAiRelevant:
+    """Source-aware AI relevance gate — the core #182 precision fix."""
+
+    def test_strong_phrase_matches_any_source(self):
+        assert lm._is_ai_relevant("New artificial intelligence rule", "Federal Register - AI")
+        assert lm._is_ai_relevant("NIST AI RMF update", "Federal Register - AI")
+        assert lm._is_ai_relevant("Guidance on automated decision-making", "White House")
+
+    def test_bare_token_rejected_on_broad_federal_register_feed(self):
+        # These are exactly the false positives #182 targets: a grant/committee
+        # notice that merely contains "AI" or "algorithm" must NOT surface from
+        # the broad Federal Register feed.
+        assert not lm._is_ai_relevant("Notice of funding: AI Corridor transportation grant", "Federal Register - AI")
+        assert not lm._is_ai_relevant(
+            "Advisory committee meeting; algorithm for quota allocation", "Federal Register - AI"
+        )
+        assert not lm._is_ai_relevant("ML export classification notice", "Federal Register - AI")
+
+    def test_bare_token_allowed_only_for_source_scoped_feed(self):
+        # The NIST CSRC feed's corpus is already on-topic, so a bare token is OK.
+        assert lm._is_ai_relevant("AI publication draft", "NIST CSRC")
+        # ...but the same bare token on the broad feed is rejected.
+        assert not lm._is_ai_relevant("AI publication draft", "Federal Register - AI")
+
+    def test_non_ai_content_rejected_everywhere(self):
+        assert not lm._is_ai_relevant("Quarterly budget report", "Federal Register - AI")
+        assert not lm._is_ai_relevant("Quarterly budget report", "NIST CSRC")
+
+
+class TestFederalRegisterQueryScoping:
+    """#182: the Federal Register feed URL is document-type scoped."""
+
+    def _fr_url(self):
+        return next(f["url"] for f in lm.RSS_FEEDS if f["name"] == "Federal Register - AI")
+
+    def test_query_is_type_scoped(self):
+        url = self._fr_url()
+        # Presidential documents + rules + proposed rules + notices, not an
+        # unscoped term-only query.
+        assert "conditions%5Btype%5D%5B%5D=PRESDOCU" in url
+        assert "conditions%5Btype%5D%5B%5D=RULE" in url
+        assert "per_page=50" in url
+
+    def test_still_targets_documents_endpoint(self):
+        assert "federalregister.gov/api/v1/documents.rss" in self._fr_url()
+
+
+# ── fetch_rss_feeds (mocked feedparser) ───────────────────────────────────────
+
+
+def _mock_feed(entries, *, bozo=False):
+    feed = mock.MagicMock()
+    feed.bozo = bozo
+    feed.bozo_exception = Exception("bad") if bozo else None
+    feed.entries = entries
+    return feed
+
+
+def _entry(title, *, summary="", link="https://example.gov/x", days_ago=1):
+    published = (datetime.utcnow() - timedelta(days=days_ago)).timetuple()[:9]
+    e = mock.MagicMock()
+    e.title = title
+    e.summary = summary
+    e.link = link
+    e.published_parsed = published
+    # attribute presence matters (getattr / hasattr checks in code)
+    del e.updated_parsed
+    return e
+
+
+class TestFetchRssFeeds:
+    @pytest.fixture(autouse=True)
+    def _require_feedparser(self, monkeypatch):
+        monkeypatch.setattr(lm, "FEEDPARSER_AVAILABLE", True)
+
+    def test_filters_out_irrelevant_broad_feed_items(self, monkeypatch):
+        feed = _mock_feed(
+            [
+                _entry("Removing barriers to artificial intelligence", link="https://a.gov/1"),
+                _entry("AI Corridor highway grant notice", link="https://a.gov/2"),
+            ]
+        )
+        monkeypatch.setattr(lm.feedparser, "parse", lambda url: feed)
+        monkeypatch.setattr(
+            lm,
+            "RSS_FEEDS",
+            [{"name": "Federal Register - AI", "url": "x", "category_hint": "legislation"}],
+        )
+        out = lm.fetch_rss_feeds(lm.RSS_FEEDS)
+        titles = [e.title for e in out]
+        assert "Removing barriers to artificial intelligence" in titles
+        assert "AI Corridor highway grant notice" not in titles
+
+    def test_skips_entries_older_than_lookback(self, monkeypatch):
+        feed = _mock_feed([_entry("NIST AI RMF profile released", days_ago=lm.LOOKBACK_DAYS + 10)])
+        monkeypatch.setattr(lm.feedparser, "parse", lambda url: feed)
+        monkeypatch.setattr(
+            lm,
+            "RSS_FEEDS",
+            [{"name": "NIST CSRC", "url": "x", "category_hint": "nist_standard"}],
+        )
+        assert lm.fetch_rss_feeds(lm.RSS_FEEDS) == []
+
+    def test_bozo_feed_skipped_without_raising(self, monkeypatch):
+        monkeypatch.setattr(lm.feedparser, "parse", lambda url: _mock_feed([], bozo=True))
+        monkeypatch.setattr(
+            lm,
+            "RSS_FEEDS",
+            [{"name": "Federal Register - AI", "url": "x", "category_hint": "legislation"}],
+        )
+        assert lm.fetch_rss_feeds(lm.RSS_FEEDS) == []
+
+    def test_no_feedparser_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(lm, "FEEDPARSER_AVAILABLE", False)
+        assert lm.fetch_rss_feeds(lm.RSS_FEEDS) == []
+
+
+# ── generate_diff (previously untested) ───────────────────────────────────────
+
+
+class TestGenerateDiff:
+    def test_new_publication_detected(self):
+        rss = [
+            lm.RSSEntry(
+                title="New AI EO",
+                url="https://new.gov/eo",
+                published=datetime.utcnow(),
+                source="White House",
+                category_hint="executive_order",
+            )
+        ]
+        report = lm.generate_diff([], {}, rss)
+        assert len(report.new_publications) == 1
+        assert report.new_publications[0].url == "https://new.gov/eo"
+
+    def test_known_url_not_flagged_new(self):
+        known = lm.RegistryEntry(
+            id="eo-1",
+            title="Known",
+            url="https://known.gov/eo",
+            date="2025-01-01",
+            status="active",
+            category="executive_order",
+            relevance="r",
+        )
+        rss = [
+            lm.RSSEntry(
+                title="Known",
+                url="https://known.gov/eo",
+                published=datetime.utcnow(),
+                source="White House",
+                category_hint="executive_order",
+            )
+        ]
+        report = lm.generate_diff([known], {known.url: known}, rss)
+        assert report.new_publications == []
+
+    def test_approaching_deadline_flagged(self):
+        soon = (datetime.utcnow() + timedelta(days=10)).strftime("%Y-%m-%d")
+        entry = lm.RegistryEntry(
+            id="m-1",
+            title="Deadline soon",
+            url="https://d.gov/1",
+            date="2025-01-01",
+            status="active",
+            category="omb_memo",
+            relevance="r",
+            compliance_deadline=soon,
+        )
+        report = lm.generate_diff([entry], {entry.url: entry}, [])
+        assert len(report.approaching_deadlines) == 1
+        assert report.approaching_deadlines[0][0].id == "m-1"
+
+    def test_far_deadline_not_flagged(self):
+        far = (datetime.utcnow() + timedelta(days=365)).strftime("%Y-%m-%d")
+        entry = lm.RegistryEntry(
+            id="m-2",
+            title="Deadline far",
+            url="https://d.gov/2",
+            date="2025-01-01",
+            status="active",
+            category="omb_memo",
+            relevance="r",
+            compliance_deadline=far,
+        )
+        report = lm.generate_diff([entry], {entry.url: entry}, [])
+        assert report.approaching_deadlines == []


### PR DESCRIPTION
## Summary

Closes #182. The landscape monitor's Federal Register feed used an **unscoped** `conditions[term]=artificial intelligence` query plus a loose `AI_KEYWORDS` regex that matched a bare `AI` / `ML` / `algorithm`. Result: grant notices, advisory-committee meetings, Medicare rules, and export bulletins that merely mention "AI" surfaced as **new publications** — noise that erodes the signal. The script also had **zero test coverage**.

## Change

1. **Scoped Federal Register query** — restrict to the document **types** that carry AI governance: `PRESDOCU` (presidential documents), `RULE`, `PRORULE` (proposed rules), `NOTICE`; `order=newest`, `per_page=50`. No longer term-only.
2. **Source-aware relevance gate `_is_ai_relevant`** —
   - A **strong governance phrase** (`artificial intelligence`, `NIST AI`, `AI RMF`, `automated decision-making`, `AI safety`/`governance`, `algorithmic accountability`, `foundation/frontier model`, …) qualifies from **any** feed.
   - A **weak bare token** (`AI`/`ML`/`algorithm`) qualifies **only** when the feed source is already topic-scoped (NIST CSRC). The broad Federal Register feed no longer surfaces bare-token noise.

## Verification against LIVE Federal Register data

Ran the new gate over the 20 most-recent `term=artificial intelligence` items:

- **All 20** noise items (reactor-safeguards meeting, Medicare hospice rule, submarine-cable rule, geospatial committee, …) are **correctly dropped**.
- Real AI-governance titles — **EO 14179**, the **AI Action Plan RFI**, the **AI RMF framework**, "Ensuring Safe, Secure, and Trustworthy… AI" — are all **kept**.

| Check | Result |
|-------|--------|
| `pytest scripts/tests/` | **446 pass** (new `test_landscape_monitor.py`, 14 tests — the file had **0** before) |
| `validate-docs` / `generate-index --check` | green |
| `ruff check scripts/` | clean |
| `landscape-check --dry-run` | prints the scoped feed URL, exit 0 |

New tests (mocked `feedparser`, no network): relevance gate strong/weak/source-scoped/negative; FR query type-scoping; `fetch_rss_feeds` filtering / lookback / bozo-feed / no-feedparser; `generate_diff` new-pub / known-url / deadline.

## Note / follow-up

The scoped `documents.rss` feed does not itself let us drop `NOTICE`-heavy noise at the API (the RSS endpoint returns the newest across the requested types), so the **relevance gate is the primary precision mechanism** — which is why it's the more thoroughly tested half. `landscape-check` is not wired into CI (no scheduled workflow); these are the first tests to exercise the RSS path at all.

## Rollback

Revert the PR. Pure query-string + filter-logic change + new tests; no network/auth/data surface change (still read-only RSS fetch).

## Security Impact

None functional. Reduces false-positive governance alerts (better SA-5 signal). Fetch remains read-only over TLS.

AI-assisted (OpenCode). Requires human review.
