### PR TITLE
fix(new-project): catch backtick dangling refs + exclude playbook-doc navigators (#189)

### DIFF
--- a/.agents/skills/ato-package/SKILL.md
+++ b/.agents/skills/ato-package/SKILL.md
@@ -93,8 +93,9 @@ Populate Status as: **Complete**, **Partial**, or **Missing**.
 Pull last-updated dates from file frontmatter `last_updated` field if present,
 otherwise use the git log date (`git log -1 --format=%ai -- <path>`).
 
-Reference `docs/SECURITY-CONTROLS.md` for NIST control family mappings and
-`docs/TRACEABILITY.md` for the control-to-document matrix.
+Reference `docs/SECURITY-CONTROLS.md` for NIST control family mappings and the
+playbook's control-to-document matrix (docs/TRACEABILITY.md in the
+agentic-coding-playbook repo).
 
 ### Step 4: Gap Analysis
 
@@ -157,6 +158,6 @@ Output a readiness assessment in this format:
 - This skill is **read-only** — it inventories and validates but does not create or modify artifacts.
 - The package index (`docs/ato-package-index.md`) is the only file this skill generates.
 - All sign-off lines require human signatures. The agent cannot sign on behalf of reviewers.
-- NIST control mappings come from `docs/SECURITY-CONTROLS.md` and `docs/TRACEABILITY.md`.
+- NIST control mappings come from `docs/SECURITY-CONTROLS.md` and the playbook's traceability matrix (docs/TRACEABILITY.md in the agentic-coding-playbook repo).
 - Use dependency skills to fill gaps: `federal-risk-assessment`, `federal-pre-deployment-check`, `federal-decision-records`.
-- **Policy reference:** `docs/SECURITY-CONTROLS.md` (control mappings), `docs/TRACEABILITY.md` (control-to-document matrix).
+- **Policy reference:** `docs/SECURITY-CONTROLS.md` (control mappings); the playbook traceability matrix (docs/TRACEABILITY.md in the agentic-coding-playbook repo) for the control-to-document matrix.

--- a/.agents/skills/federal-decision-records/SKILL.md
+++ b/.agents/skills/federal-decision-records/SKILL.md
@@ -207,4 +207,5 @@ Present the generated index to the user.
   not break compatibility with MADR tooling.
 - **Policy references:** `AGENTS.md` (agent decisions), `docs/CODING_PRACTICES.md`
   (coding decisions), `docs/SECURITY-CONTROLS.md` (control guidance),
-  `docs/TRACEABILITY.md` (control mappings).
+  the playbook's control-mapping matrix (docs/TRACEABILITY.md in the
+  agentic-coding-playbook repo).

--- a/.agents/skills/federal-pre-deployment-check/SKILL.md
+++ b/.agents/skills/federal-pre-deployment-check/SKILL.md
@@ -168,5 +168,5 @@ with references to the relevant policy documents (use the
 - The reviewer MUST NOT be the same person who directed the agent (per checklist instructions).
 - Automated checks are best-effort — tool availability varies by environment.
 - The automated checks (`make pre-deploy`) are read-only. They do not modify files, install packages, or make network calls.
-- All 60 items trace back to NIST SP 800-53 controls via `docs/TRACEABILITY.md` Table 3.
-- **Policy reference:** `checklists/pre-deployment.md` for the full checklist, `docs/TRACEABILITY.md` for control mappings.
+- All 60 items trace back to NIST SP 800-53 controls via the playbook's traceability matrix (docs/TRACEABILITY.md in the agentic-coding-playbook repo) Table 3.
+- **Policy reference:** `checklists/pre-deployment.md` for the full checklist; the playbook traceability matrix (docs/TRACEABILITY.md in the agentic-coding-playbook repo) for control mappings.

--- a/.agents/skills/federal-risk-assessment/SKILL.md
+++ b/.agents/skills/federal-risk-assessment/SKILL.md
@@ -14,7 +14,7 @@ dependencies: []
 # Federal Risk Assessment
 
 This skill walks users through the risk assessment template from
-`templates/risk-assessment.md` interactively, helping them complete each
+`docs/risk-assessment.md` interactively, helping them complete each
 section with context-appropriate guidance.
 
 ## When to Use
@@ -26,7 +26,7 @@ section with context-appropriate guidance.
 
 ## How It Works
 
-Read `templates/risk-assessment.md` first to discover the current worksheet structure
+Read `docs/risk-assessment.md` first to discover the current worksheet structure
 (sections, capabilities, data types, threats, control areas). Then guide the user
 through each section, explain what's needed, ask questions, and fill in the template.
 
@@ -65,7 +65,7 @@ Then walk through the capabilities checklist:
 
 > "Which of these capabilities will the agent use in this project? (Yes/No for each)"
 
-Present the capabilities from `templates/risk-assessment.md` Section 2
+Present the capabilities from `docs/risk-assessment.md` Section 2
 (Agent Capabilities Inventory). Read the template to discover the current list.
 For each capability, ask Yes/No.
 
@@ -78,12 +78,12 @@ Present the data types table and ask for each:
 > "For each data type, tell me if it's present in the system, its classification,
 > and whether the agent needs access to it."
 
-Walk through the data types listed in `templates/risk-assessment.md` Section 3
+Walk through the data types listed in `docs/risk-assessment.md` Section 3
 (Data Classification). Read the template to discover the current list.
 
 #### 3.2 Data Flow
 
-For each data destination in `templates/risk-assessment.md` Section 3.2
+For each data destination in `docs/risk-assessment.md` Section 3.2
 (Data Flow), ask if it's authorized and encrypted.
 
 ### Section 4: Threat Analysis
@@ -112,7 +112,7 @@ After completing all threats, summarize with the risk tolerance table:
 
 ### Section 5: Control Assessment
 
-Walk through the control areas listed in `templates/risk-assessment.md` Section 5
+Walk through the control areas listed in `docs/risk-assessment.md` Section 5
 (Control Implementation Status). Read the template to discover the current list.
 
 > "For each control area, what's the current implementation status?"
@@ -162,5 +162,5 @@ signed by the System Owner and ISSO before it becomes part of the ATO documentat
 - The completed assessment is a **draft** requiring human review and sign-off.
 - Risk scores are based on the user's input — the agent does not override or second-guess ratings.
 - Threat descriptions are pre-filled from OWASP and NIST sources. See `references/THREAT_CATALOG.md`.
-- The full template is at `templates/risk-assessment.md`. This skill makes it interactive, it does not change the template structure.
-- **Policy reference:** `templates/risk-assessment.md` (template), `docs/SECURITY-CONTROLS.md` (control guidance).
+- The full template is at `docs/risk-assessment.md`. This skill makes it interactive, it does not change the template structure.
+- **Policy reference:** `docs/risk-assessment.md` (template), `docs/SECURITY-CONTROLS.md` (control guidance).

--- a/scripts/playbook_validator/new_project.py
+++ b/scripts/playbook_validator/new_project.py
@@ -62,9 +62,7 @@ DOWNSTREAM_SKILLS = (
     "code-review",
     "federal-decision-records",
     "federal-pre-deployment-check",
-    "federal-repo-setup",
     "federal-risk-assessment",
-    "federal-security-controls-lookup",
 )
 
 # Excluded (playbook-operational) skills, kept explicit for the e2e test and
@@ -73,6 +71,14 @@ EXCLUDED_SKILLS = (
     "federal-agents-config",
     "federal-landscape-update",
     "project-bootstrap",
+    # Playbook-doc NAVIGATORS (#189): these skills exist to navigate the
+    # playbook's own reference docs (federal-security-controls-lookup reads
+    # docs/TRACEABILITY.md + INDEX.yaml; federal-repo-setup converts
+    # docs/GETTING-STARTED.md). Those docs are playbook-only and not copied
+    # downstream, so the skills are inert / dangling in a bootstrapped project.
+    # A downstream project consults the playbook directly instead.
+    "federal-security-controls-lookup",
+    "federal-repo-setup",
 )
 
 # Git-ignore entries written into the bootstrapped project so the fallback

--- a/scripts/tests/test_e2e_new_project.py
+++ b/scripts/tests/test_e2e_new_project.py
@@ -55,6 +55,12 @@ UNIVERSAL_PROSE_FINGERPRINTS = (
 # Markdown inline links: [text](target)
 _MD_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
 
+# Backtick inline-code path references, e.g. `docs/TRACEABILITY.md`, `INDEX.yaml`.
+# These are the refs the markdown-link check misses (#189): a copied skill that
+# points at a playbook-only path in inline code dangles downstream but the
+# link-only check stays green.
+_BACKTICK_PATH_RE = re.compile(r"`([A-Za-z0-9_][A-Za-z0-9_./-]*\.(?:md|yaml|yml|json))`")
+
 
 @pytest.fixture(scope="module")
 def bootstrapped_project(tmp_path_factory) -> Path:
@@ -177,6 +183,54 @@ def test_no_dangling_markdown_links_including_skills(bootstrapped_project: Path)
             if not resolved.exists():
                 dangling.append(f"{md_file.relative_to(bootstrapped_project)} -> {link}")
     assert not dangling, "dangling intra-project links found:\n" + "\n".join(dangling)
+
+
+def test_no_dangling_backtick_refs_in_copied_skills(bootstrapped_project: Path):
+    """Backtick inline-code path refs in COPIED skills resolve in the project (#189).
+
+    The markdown-link check above only catches `[text](target)` syntax. Copied
+    downstream skills reference playbook-only files as inline code (e.g.
+    `` `docs/TRACEABILITY.md` ``, `` `INDEX.yaml` ``) which are NOT copied into a
+    bootstrapped project — so they ship a broken reference while the link-only
+    check stays green.
+
+    Scope: `.md` under the copied ``skills/`` tree. To stay fail-closed without
+    false positives, a backtick token is a dangle only when it is a KNOWN
+    playbook-only path (a `docs/…`, `data/…`, or root inventory file the
+    playbook owns) that the bootstrap did not copy — not an illustrative example
+    filename (`SECURITY.md` a user creates, a `README.md` the skill generates)
+    that merely happens to share a name with a repo-root file.
+    """
+    # Playbook-internal directories/files whose contents are NOT copied
+    # wholesale downstream. A backtick ref under these that isn't present in the
+    # project is a genuine dangle.
+    playbook_only_prefixes = ("docs/", "data/", "templates/")
+    playbook_only_files = {"INDEX.yaml"}
+    # Paths a skill CREATES at runtime (its own output), not a playbook-only
+    # dependency — referencing these is correct, not a dangle.
+    skill_generated = {"docs/ato-package-index.md"}
+
+    skills_dir = bootstrapped_project / "skills"
+    dangling: list[str] = []
+    for md_file in skills_dir.rglob("*.md"):
+        text = md_file.read_text(encoding="utf-8")
+        for ref in _BACKTICK_PATH_RE.findall(text):
+            ref_path = ref.strip()
+            if ref_path in skill_generated:
+                continue
+            is_playbook_owned = ref_path.startswith(playbook_only_prefixes) or ref_path in playbook_only_files
+            if not is_playbook_owned:
+                continue  # illustrative / user-created / skill-generated name
+            # Resolves inside the project (root-relative or file-relative)? OK.
+            if (bootstrapped_project / ref_path).exists():
+                continue
+            if (md_file.parent / ref_path).exists():
+                continue
+            dangling.append(f"{md_file.relative_to(bootstrapped_project)} -> `{ref_path}`")
+    assert not dangling, (
+        "copied skills reference playbook-only files that are not in the "
+        "bootstrapped project (#189):\n" + "\n".join(sorted(dangling))
+    )
 
 
 def test_referenced_docs_exist_in_project(bootstrapped_project: Path):


### PR DESCRIPTION
## Summary

Closes #189. Off `main` (independent of the generator stack). The new-project e2e dangling-link test only matched markdown-link syntax `[text](target)` and missed **backtick inline-code** refs. Copied downstream skills referenced playbook-only files as inline code — `` `docs/TRACEABILITY.md` ``, `` `INDEX.yaml` ``, `` `docs/GETTING-STARTED.md` `` — that `new_project.py` does not copy, so they dangled in a bootstrapped project while the link-only check stayed green.

## Change

1. **New test `test_no_dangling_backtick_refs_in_copied_skills`** — scans the copied `skills/` tree for backtick path refs to playbook-owned dirs (`docs/`, `data/`, `templates/`) + `INDEX.yaml` that don't resolve in the bootstrapped project. **Fail-closed**, but scoped to avoid false positives: ignores illustrative / user-created names (e.g. a `SECURITY.md` a user makes, a `README.md` the skill generates) and skill-generated outputs (`docs/ato-package-index.md`).
2. **Excluded two playbook-doc NAVIGATOR skills** from downstream copy (same rationale as #145's playbook-operational exclusions): `federal-security-controls-lookup` (its whole job is navigating `docs/TRACEABILITY.md` + `INDEX.yaml`) and `federal-repo-setup` (converts `docs/GETTING-STARTED.md`). Both are inert downstream where those docs don't exist. Moved from `DOWNSTREAM_SKILLS` → `EXCLUDED_SKILLS`.
3. **Reworded residual refs** in the 3 skills that stay downstream (`ato-package`, `federal-decision-records`, `federal-pre-deployment-check`) to name the upstream *agentic-coding-playbook repo* instead of a dangling backtick path; retargeted `federal-risk-assessment`'s `templates/risk-assessment.md` refs to the copied `docs/risk-assessment.md` project path.

## Verification

| Check | Result |
|-------|--------|
| `pytest scripts/tests/` | **433 pass** |
| new backtick check — fail-closed proof | injecting `` `docs/TRACEABILITY.md` `` into a downstream skill → test **fails**; restore → passes |
| `test_skill_partition_is_exhaustive` / `test_excluded_skills_absent` | pass (the 2 moved skills classified) |
| `validate-docs` / `validate-skills` / `generate-index --check` | green |
| `ruff check scripts/` | clean |

## Design note (fail-closed vs false-positive)

A backtick token is flagged only when it names a **playbook-owned** path (`docs/`, `data/`, `templates/`, or `INDEX.yaml`) that isn't in the project — not any backticked filename. This keeps the guard fail-closed on the real leak class while not tripping on example/generated names. The two excluded navigator skills still exist in the repo (validate-skills covers them); they're just not shipped downstream.

## Rollback

Revert. Test + copy-allowlist + skill-doc wording only; no runtime/auth/data surface.

## Security Impact

Improves downstream doc integrity (SA-5) — bootstrapped federal projects no longer ship broken references to playbook-internal files.

Split from #146 (whose stated defect was already fixed by PR #144). AI-assisted (OpenCode). Requires human review.
