### PR TITLE
feat(generate): neutral document inventory from INDEX.yaml (#199)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Skills convert best practices into step-by-step workflows that any AI coding age
 
 ## Developer Tools
 
-All validation and generation tools live in the `scripts/playbook_validator/` Python package (494 tests).
+All validation and generation tools live in the `scripts/playbook_validator/` Python package (500 tests).
 
 ```bash
 make help              # Show all available commands
@@ -210,7 +210,7 @@ agentic-coding-playbook/
 ├── data/
 │   └── federal-ai-landscape.yaml    # Machine-readable guidance registry
 ├── scripts/
-│   ├── playbook_validator/          # Python validation package (494 tests)
+│   ├── playbook_validator/          # Python validation package (500 tests)
 │   └── tests/                       # TDD test suite
 ├── skills/                          # 12 executable compliance procedures
 ├── templates/                       # PROJECT_PLAN.md, AGENTS.md.template

--- a/docs/AGENT-INSTRUCTIONS.md
+++ b/docs/AGENT-INSTRUCTIONS.md
@@ -16,7 +16,7 @@ Model-agnostic reference for any AI coding agent working in this repository. Rea
 ## Quick Reference
 
 ```bash
-# Validation (Python package — 494 tests)
+# Validation (Python package — 500 tests)
 PYTHONPATH=scripts python3 -m playbook_validator validate-docs
 PYTHONPATH=scripts python3 -m playbook_validator validate-skills
 PYTHONPATH=scripts python3 -m playbook_validator validate-landscape

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,3 +40,55 @@ Canonical index of all documentation in the agentic-coding-playbook.
 
 - **Agent entry point:** [CONTEXT-GUIDE.md](../CONTEXT-GUIDE.md)
 - **Project instructions:** [AGENTS.md](../AGENTS.md)
+
+## Complete Document Inventory
+
+> The tier tables above are the **human onboarding order** (what to read first).
+> The table below is the complete machine inventory, generated from
+> [`INDEX.yaml`](../INDEX.yaml) — its `tier` is the machine-inventory
+> classification, which intentionally differs from this page's onboarding tiers
+> and from `CONTEXT-GUIDE.md`'s context-budget loading tiers (three distinct
+> purposes; see [tier taxonomies](#tier-taxonomies)).
+
+<!-- GENERATED:DOC_INVENTORY:START — do not edit, run: make generate -->
+| Document | Tier | Purpose |
+|----------|------|---------|
+| `AGENTS.md` | 1 | Best practices for AI coding agent behavior in federal development environments — includes behavioral standards, engineering discipline enforcement, and verification requirements |
+| `CONTEXT-GUIDE.md` | 1 | Compact routing document for AI agents — read this FIRST to determine which documents to load for your current task |
+| `PLAYBOOK.md` | 1 | Step-by-step guide for starting a federal coding project with AI agents |
+| `docs/AGENT-IDENTITY.md` | 1 | Agent identity management aligned with NCCOE concept paper — authentication, authorization, delegation, and audit logging for AI agents |
+| `docs/AGENT-INSTRUCTIONS.md` | 1 | Model-agnostic repo-specific reference for any AI coding agent working in this repository |
+| `docs/CODING_PRACTICES.md` | 1 | Secure coding standards for AI-assisted development — input validation, secrets management, dependency security, architecture discipline, change safety, SOLID principles, OWASP/SSDF alignment |
+| `docs/CODING_STANDARDS_COMPACT.md` | 1 | LLM-optimized coding standards for inclusion in code generation context (~500 words) |
+| `docs/SECURITY-CONTROLS.md` | 1 | 800-53 control overlay mapping 35 security controls across 10 families to concrete AI agent behaviors and verification methods |
+| `templates/CONTEXT-GUIDE.project.md` | 1 | Compact routing document for AI agents working in this project — read this FIRST to determine which documents to load for your current task |
+| `docs/AI-CONTRIBUTION-POLICY.md` | 2 | Canonical policy governing AI-assisted contributions — human accountability, disclosure, provenance, verification, data handling, security review, and licensing posture for federal AI-assisted development |
+| `docs/FEDERAL-AI-LANDSCAPE.md` | 2 | Canonical catalog of federal AI guidance, executive orders, standards, and legislation relevant to AI-assisted software development |
+| `docs/GETTING-STARTED.md` | 2 | Step-by-step guide for setting up a development repository with security controls for AI coding agents |
+| `docs/TRACEABILITY.md` | 2 | Bidirectional mapping between NIST 800-53 controls, OWASP risks, document sections, and checklist items |
+| `templates/SKILL.md.template` | 2 | One sentence describing what this skill does and when to use it |
+| `templates/doc.md.template` | 2 | One-line summary of what this document covers |
+| `checklists/pre-deployment.md` | 3 | 62-item security checklist for deploying AI-assisted code — secrets, input validation, auth, dependencies, testing, infrastructure, accessibility |
+| `docs/PROMPT-INJECTION-DEFENSE.md` | 3 | Implementation patterns for defending against prompt injection in AI-assisted federal applications |
+| `docs/ROADMAP.md` | 3 | Long-term plan for the Agentic Coding Playbook — making it a living resource for federal engineers learning agentic coding |
+| `examples/AGENTS.md.example` | 3 | Completed example showing a thin, project-specific AGENTS.md layered on the universal contract for a hypothetical federal HR benefits portal |
+| `templates/AGENTS.md.template` | 3 | Copy-paste template for a thin, project-specific AGENTS.md that layers on top of the universal Federal AI Agent behavioral contract |
+| `templates/PROJECT_PLAN.md` | 3 | Starting point for a new federal coding project — fill this out and let the AI agent set up everything else |
+| `templates/privacy-impact-assessment.md` | 3 | PIA template for federal systems using AI components — data flows, privacy risks, mitigations, and compliance sign-off |
+| `templates/risk-assessment.md` | 3 | Structured risk assessment template aligned with NIST AI RMF — threat analysis, control assessment, and sign-off |
+<!-- GENERATED:DOC_INVENTORY:END -->
+
+### Tier taxonomies
+
+This repository uses the word "tier" for three **distinct** purposes; they are
+curated independently on purpose and are not expected to match:
+
+| View | Source | Meaning |
+|------|--------|---------|
+| Machine inventory tier | `INDEX.yaml` frontmatter `tier` | Load priority for an agent building context from a cold start |
+| Onboarding tier | this page's tables above | Pedagogical reading order for a new human contributor |
+| Context-budget tier | `CONTEXT-GUIDE.md` | Token-budget loading strategy (word-count aware) |
+
+A document can legitimately sit in a different tier in each view (e.g.
+`SECURITY-CONTROLS.md` is machine-inventory tier 1 but onboarding tier 2). The
+generated inventory above reflects only the machine-inventory tier.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,7 +20,7 @@ Long-term plan for making the Agentic Coding Playbook a living, learnable resour
 |--------|-------|
 | Documents | 23 |
 | Skills | 12 |
-| Tests | 494 |
+| Tests | 500 |
 | Checklist items | 62 |
 | Landscape entries | 42 |
 | NIST controls mapped | 35 |

--- a/scripts/playbook_validator/generate_index.py
+++ b/scripts/playbook_validator/generate_index.py
@@ -398,6 +398,7 @@ def generate_index(root: Path) -> None:
         inject_readme_table,
         render_skills_table,
         update_context_guide_word_counts,
+        update_doc_inventory,
         update_hardcoded_counts,
         update_landscape_summary,
         update_phase_mapping,
@@ -422,6 +423,7 @@ def generate_index(root: Path) -> None:
     update_landscape_summary(root)
     update_phase_mapping(root)
     update_roadmap_metrics(root, stats)
+    update_doc_inventory(root)
 
     print(
         f"Generated INDEX.yaml "

--- a/scripts/playbook_validator/index_updaters.py
+++ b/scripts/playbook_validator/index_updaters.py
@@ -264,6 +264,68 @@ def update_phase_mapping(root: Path) -> None:
     splice_generated_block(root / "docs" / "FEDERAL-AI-LANDSCAPE.md", "LANDSCAPE_PHASES", table)
 
 
+# ── Neutral document inventory (#199) ─────────────────────────────────
+#
+# A single generated "all documents" table sourced from INDEX.yaml — the
+# machine inventory. Per the #199 consensus, this does NOT collapse the three
+# distinct tier taxonomies (INDEX machine-inventory `tier`, docs/README human
+# onboarding order, CONTEXT-GUIDE context-budget loading): those are different
+# semantic axes and stay independently curated. This neutral inventory is the
+# de-drift win — one generated list of every doc with its INDEX tier + purpose —
+# without flattening the editorial views. It lives at the end of docs/README.md
+# under GENERATED:DOC_INVENTORY markers.
+
+_DOC_INVENTORY_REL = "docs/README.md"
+
+
+def _load_index_documents(root: Path) -> list[dict] | None:
+    """Return INDEX.yaml's `documents` list (path/title/description/tier/…), or None."""
+    index = root / "INDEX.yaml"
+    if not index.is_file():
+        return None
+    import yaml
+
+    data = yaml.safe_load(index.read_text(encoding="utf-8")) or {}
+    docs = data.get("documents")
+    return docs if isinstance(docs, list) else None
+
+
+def render_doc_inventory_table(documents: list[dict]) -> str:
+    """Render the neutral all-documents inventory table from INDEX docs (#199).
+
+    Columns: Document (path), Tier (INDEX machine tier), Purpose (INDEX
+    description). Sorted by tier then path for a stable, diffable order.
+    """
+    rows = sorted(
+        documents,
+        key=lambda d: (d.get("tier", 99), str(d.get("path", ""))),
+    )
+    lines = [
+        "| Document | Tier | Purpose |",
+        "|----------|------|---------|",
+    ]
+    for doc in rows:
+        path = str(doc.get("path", "")).strip()
+        tier = doc.get("tier", "—")
+        # description is the INDEX machine description; collapse whitespace.
+        purpose = " ".join(str(doc.get("description", "")).split())
+        lines.append(f"| `{path}` | {tier} | {purpose} |")
+    return "\n".join(lines)
+
+
+def update_doc_inventory(root: Path) -> None:
+    """Regenerate the neutral document inventory in docs/README.md (#199).
+
+    No-op if the GENERATED:DOC_INVENTORY markers or INDEX.yaml are absent. The
+    hand-curated tier tables above the markers are untouched.
+    """
+    documents = _load_index_documents(root)
+    if documents is None:
+        return
+    table = render_doc_inventory_table(documents)
+    splice_generated_block(root / _DOC_INVENTORY_REL, "DOC_INVENTORY", table)
+
+
 # ── CONTEXT-GUIDE word counts ─────────────────────────────────────────
 
 

--- a/scripts/playbook_validator/validate_docs.py
+++ b/scripts/playbook_validator/validate_docs.py
@@ -395,7 +395,35 @@ def validate_count_drift(root: Path) -> tuple[list[str], list[str]]:
                         )
 
     errors += _validate_roadmap_metrics(root)
+    errors += _validate_doc_inventory(root)
     return errors, warnings
+
+
+def _validate_doc_inventory(root: Path) -> list[str]:
+    """Guard the generated document inventory in docs/README.md (#199)."""
+    doc = root / "docs" / "README.md"
+    if not doc.is_file():
+        return []
+    text = doc.read_text(encoding="utf-8")
+    start = "<!-- GENERATED:DOC_INVENTORY:START"
+    end = "<!-- GENERATED:DOC_INVENTORY:END -->"
+    if start not in text or end not in text:
+        return []
+
+    from playbook_validator.index_updaters import (
+        _load_index_documents,
+        render_doc_inventory_table,
+    )
+
+    documents = _load_index_documents(root)
+    if documents is None:
+        return ["docs/README.md declares a DOC_INVENTORY block but INDEX.yaml is missing"]
+    expected = render_doc_inventory_table(documents).strip()
+    block = text.split(start, 1)[1].split(end, 1)[0]
+    body = block.split("\n", 1)[1].strip() if "\n" in block else ""
+    if body != expected:
+        return ["docs/README.md — document inventory is out of sync with INDEX.yaml. Run `make generate` (#199)."]
+    return []
 
 
 # Body banner "> **Version:** X.Y.Z" in the universal contract — must agree with

--- a/scripts/tests/test_generate_index.py
+++ b/scripts/tests/test_generate_index.py
@@ -741,3 +741,73 @@ class TestLandscapeDocGuard:
         )
         errors = validate_landscape_doc_summary(tmp_path)
         assert errors and "out of sync" in errors[0]
+
+
+class TestDocInventory:
+    def _write_index(self, root, docs):
+        import yaml as _yaml
+
+        (root / "INDEX.yaml").write_text(_yaml.safe_dump({"documents": docs}))
+
+    def test_render_sorts_by_tier_then_path(self):
+        from playbook_validator.index_updaters import render_doc_inventory_table
+
+        docs = [
+            {"path": "docs/z.md", "tier": 2, "description": "Zed"},
+            {"path": "AGENTS.md", "tier": 1, "description": "Contract"},
+            {"path": "docs/a.md", "tier": 1, "description": "Ay"},
+        ]
+        table = render_doc_inventory_table(docs)
+        lines = [ln for ln in table.splitlines() if ln.startswith("| `")]
+        assert lines[0].startswith("| `AGENTS.md` | 1 |")
+        assert lines[1].startswith("| `docs/a.md` | 1 |")
+        assert lines[2].startswith("| `docs/z.md` | 2 |")
+
+    def test_description_whitespace_collapsed(self):
+        from playbook_validator.index_updaters import render_doc_inventory_table
+
+        table = render_doc_inventory_table([{"path": "x.md", "tier": 1, "description": "multi\n  line   desc"}])
+        assert "| `x.md` | 1 | multi line desc |" in table
+
+    def test_update_is_noop_without_markers(self, tmp_path):
+        from playbook_validator.index_updaters import update_doc_inventory
+
+        self._write_index(tmp_path, [{"path": "a.md", "tier": 1, "description": "d"}])
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "README.md").write_text("# no markers here\n")
+        update_doc_inventory(tmp_path)  # must not raise / not add anything
+        assert "GENERATED:DOC_INVENTORY" not in (tmp_path / "docs" / "README.md").read_text()
+
+    def test_update_fills_marked_block(self, tmp_path):
+        from playbook_validator.index_updaters import update_doc_inventory
+
+        self._write_index(tmp_path, [{"path": "AGENTS.md", "tier": 1, "description": "Contract"}])
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "README.md").write_text(
+            "# R\n\n<!-- GENERATED:DOC_INVENTORY:START -->\nold\n<!-- GENERATED:DOC_INVENTORY:END -->\n"
+        )
+        update_doc_inventory(tmp_path)
+        out = (tmp_path / "docs" / "README.md").read_text()
+        assert "| `AGENTS.md` | 1 | Contract |" in out
+
+    def test_guard_flags_drift(self, tmp_path):
+        from playbook_validator.validate_docs import _validate_doc_inventory
+
+        self._write_index(tmp_path, [{"path": "AGENTS.md", "tier": 1, "description": "Contract"}])
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "README.md").write_text(
+            "# R\n\n<!-- GENERATED:DOC_INVENTORY:START -->\n"
+            "| Document | Tier | Purpose |\n|----------|------|---------|\n"
+            "| `AGENTS.md` | 9 | Contract |\n"  # wrong tier
+            "<!-- GENERATED:DOC_INVENTORY:END -->\n"
+        )
+        errors = _validate_doc_inventory(tmp_path)
+        assert errors and "out of sync" in errors[0]
+
+    def test_real_repo_inventory_consistent(self):
+        from pathlib import Path
+
+        from playbook_validator.validate_docs import _validate_doc_inventory
+
+        root = Path(__file__).resolve().parents[2]
+        assert _validate_doc_inventory(root) == []


### PR DESCRIPTION
## Summary

Closes #199. **Stacked on #200 (#197) → #196 (#142) → #188 (#184).** Merge that chain first; this PR's own diff is only the #199 changes.

`docs/README`, `CONTEXT-GUIDE.md`, and `INDEX.yaml` carry **three different tier taxonomies** for the same doc set. You asked me to run the "do we need one canonical tier?" question through consensus.

**nexus-agents `consensus_vote` (higher_order, 7 voters): 6 approve / 1 reject.** The panel (architect, security, devex, ai_ml, pm, scope_steward for; catfish against on YAGNI grounds) converged clearly: these are **genuinely different semantic axes** — machine-inventory load priority (INDEX), human onboarding order (README), context-budget loading (CONTEXT-GUIDE) — and forcing one canonical tier would **flatten deliberate editorial/pedagogical ordering**. The recommended path was: generate a neutral inventory + document the divergence, don't collapse it.

## Change (per the consensus)

- **Generate a neutral "Complete Document Inventory"** table in `docs/README.md` from `INDEX.yaml` (path + machine tier + purpose), under `GENERATED:DOC_INVENTORY` markers. This is the de-drift win — one generated list of every doc — without touching the hand-curated onboarding tables above it.
- **Added a short "Tier taxonomies" section** explaining why the three views intentionally differ (so a future maintainer doesn't "fix" them into a false conflict).
- **Fail-closed guard** `_validate_doc_inventory`: the generated block must match `INDEX.yaml`.

Deliberately **did not** unify the three tier schemes or regenerate the onboarding/context-budget tables — that was the rejected option.

## Verification

| Check | Result |
|-------|--------|
| `pytest scripts/tests/` | **458 pass** (new `TestDocInventory`: sort, whitespace, no-op-without-markers, fill, guard-drift, live-repo) |
| `validate-docs` (new inventory guard) | green |
| fail-closed proof | corrupt a tier cell → guard errors |
| `generate-index --check` | up to date; idempotent |
| `ruff check scripts/` | clean |

## Rollback

Revert. Generator + guard + one generated README section + tests; no runtime/auth/data surface.

## Security Impact

None functional. Documentation-integrity improvement (SA-5).

AI-assisted (OpenCode); consensus-reviewed (6/7 approve). Requires human review.
