### PR TITLE
docs(backend): make sandbox references backend-agnostic (acq wrapper, not sbx-only)

### DIFF
--- a/.agents/skills/federal-agents-config/scripts/generate-agents-md.py
+++ b/.agents/skills/federal-agents-config/scripts/generate-agents-md.py
@@ -238,7 +238,7 @@ proceeds — this project does **not** vendor a copy of them (to avoid drift).
 - **How it is provided:** the universal contract is made available by your
   environment at `~/.agentic-coding-playbook/AGENTS.md` (override with
   `$AGENTIC_CODING_PLAYBOOK_HOME`). See this project's README for the supported
-  setup (the `agentic-coding-patterns` sbx mixin kit). If the home path is
+  setup (the `agentic-coding-patterns` `acq` provisioning kit). If the home path is
   unavailable, a git-ignored fallback cache at `.agents/cache/AGENTS.universal.md`
   may be populated automatically.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,47 +171,59 @@ These hooks run automatically on `git commit` and check for:
 
 **CI enforces the same checks** via `make ci`, so hooks are not required — they just provide faster feedback during local development.
 
-#### Working in SBX Containers
+#### Working in a Sandbox Backend
 
-Most users will be working **inside Docker SBX containers** per the [Quickstart guidance](https://github.com/GSA-TTS/agentic-coding-quickstart). This creates additional considerations for pre-commit hooks.
+Most contributors work **inside a sandbox backend** provisioned via the
+[`acq` wrapper](https://github.com/GSA-TTS/agentic-coding-quickstart) — `acq`
+selects the active backend (currently **SBX** or **MSB**; more may be added),
+so the commands below are backend-agnostic. This creates additional
+considerations for pre-commit hooks.
 
-**Installing the pre-commit tools in a container:**
+**Installing the pre-commit tools in a sandbox:**
 
-When you run `make setup` or `make install-hooks` inside an SBX container, the pre-commit tools are installed in that container's environment:
+When you run `make setup` or `make install-hooks` inside a sandbox, the
+pre-commit tools are installed in that sandbox's environment:
 
 ```bash
-sbx exec <sandbox-name> make install-hooks
+acq exec <sandbox-name> make install-hooks
 ```
+
+> `acq exec` routes to whichever backend is active. If you are calling a
+> backend CLI directly instead of through `acq`, substitute its exec command
+> (e.g. `sbx exec …` for the SBX backend).
 
 **Two workflows for committing changes:**
 
-**Workflow A: Edit in container, verify in container, commit on host**
-1. Edit files inside the SBX container
-2. Run `make ci` inside the container to verify all checks pass
-3. Exit the container and commit from your host machine
+**Workflow A: Edit in the sandbox, verify in the sandbox, commit on host**
+1. Edit files inside the sandbox
+2. Run `make ci` inside the sandbox to verify all checks pass
+3. Exit the sandbox and commit from your host machine
 4. Pre-commit hooks (if installed on host) will run again on commit
 
 This workflow is recommended because:
-- Keeps git history on the host (persistent across container restarts)
+- Keeps git history on the host (persistent across sandbox restarts)
 - Verifies changes in the same environment where they'll run in CI
-- No risk of losing commits when containers are destroyed
+- No risk of losing commits when sandboxes are destroyed
 
-**Workflow B: Edit in container, install hooks in container, commit in container**
-1. Edit files inside the SBX container
-2. Install pre-commit hooks inside the container: `make install-hooks`
-3. Commit changes inside the container
+**Workflow B: Edit in the sandbox, install hooks in the sandbox, commit in the sandbox**
+1. Edit files inside the sandbox
+2. Install pre-commit hooks inside the sandbox: `make install-hooks`
+3. Commit changes inside the sandbox
 
-**Important:** SBX containers are ephemeral. If the container is destroyed or recreated, any hooks installed inside it will be lost. You'll need to re-run `make install-hooks` in the new container.
+**Important:** Sandboxes are ephemeral. If the sandbox is destroyed or
+recreated, any hooks installed inside it will be lost. You'll need to re-run
+`make install-hooks` in the new sandbox.
 
 **Recommended practice:**
 
-Before committing on your host machine, verify changes in the container first:
+Before committing on your host machine, verify changes in the sandbox first:
 
 ```bash
-sbx exec <sandbox-name> make ci
+acq exec <sandbox-name> make ci
 ```
 
-This ensures all checks pass in the standardized SBX environment before you commit. CI will run the same checks, so catching issues early saves time.
+This ensures all checks pass in the standardized sandbox environment before you
+commit. CI will run the same checks, so catching issues early saves time.
 
 ## Before Every PR
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,9 +175,8 @@ These hooks run automatically on `git commit` and check for:
 
 Most contributors work **inside a sandbox backend** provisioned via the
 [`acq` wrapper](https://github.com/GSA-TTS/agentic-coding-quickstart) — `acq`
-selects the active backend (currently **SBX** or **MSB**; more may be added),
-so the commands below are backend-agnostic. This creates additional
-considerations for pre-commit hooks.
+selects the active backend, so the commands below are backend-agnostic. This
+creates additional considerations for pre-commit hooks.
 
 **Installing the pre-commit tools in a sandbox:**
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,13 @@ it to be provided by the environment at a conventional location:
 ~/.agentic-coding-playbook/AGENTS.md      # (override with $AGENTIC_CODING_PLAYBOOK_HOME)
 ```
 
-The supported way to provision it is the **`agentic-coding-patterns` sbx mixin
-kit**, which makes the contract available to agents in a sandboxed environment:
+The supported way to provision it is the **`agentic-coding-patterns` `acq`
+provisioning kit**, applied by the [`acq` wrapper](https://github.com/GSA-TTS/agentic-coding-quickstart),
+which selects a sandbox backend (currently **SBX** or **MSB**; the neutral kit
+format supports adding more) and makes the contract available to agents in a
+sandboxed environment:
 
-<https://github.com/GSA-TTS/agentic-coding-patterns/tree/main/integrations/isolation/sbx-kits>
+<https://github.com/GSA-TTS/agentic-coding-patterns/tree/main/integrations/isolation/acq-kits>
 
 If the home path is unavailable, projects bootstrapped by this playbook ship a
 self-contained probe (`scripts/ensure-contract.py`) that populates a

--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ it to be provided by the environment at a conventional location:
 
 The supported way to provision it is the **`agentic-coding-patterns` `acq`
 provisioning kit**, applied by the [`acq` wrapper](https://github.com/GSA-TTS/agentic-coding-quickstart),
-which selects a sandbox backend (currently **SBX** or **MSB**; the neutral kit
-format supports adding more) and makes the contract available to agents in a
+which selects a sandbox backend and makes the contract available to agents in a
 sandboxed environment:
 
 <https://github.com/GSA-TTS/agentic-coding-patterns/tree/main/integrations/isolation/acq-kits>

--- a/examples/AGENTS.md.example
+++ b/examples/AGENTS.md.example
@@ -53,7 +53,7 @@ proceeds — this project does **not** vendor a copy of them (to avoid drift).
 - **How it is provided:** the universal contract is made available by your
   environment at `~/.agentic-coding-playbook/AGENTS.md` (override with
   `$AGENTIC_CODING_PLAYBOOK_HOME`). See this project's README for the supported
-  setup (the `agentic-coding-patterns` sbx mixin kit). If the home path is
+  setup (the `agentic-coding-patterns` `acq` provisioning kit). If the home path is
   unavailable, a git-ignored fallback cache at `.agents/cache/AGENTS.universal.md`
   may be populated automatically.
 

--- a/scripts/playbook_validator/ensure_contract.py
+++ b/scripts/playbook_validator/ensure_contract.py
@@ -51,7 +51,7 @@ from playbook_validator.frontmatter import extract_frontmatter, parse_frontmatte
 # ── Convention constants (single source of truth) ───────────────────────────
 
 # Environment-agnostic canonical home for the universal contract. Any provider
-# (the sbx mixin kit, a dotfiles setup, a manual clone) may satisfy it.
+# (the acq provisioning kit, a dotfiles setup, a manual clone) may satisfy it.
 DEFAULT_HOME = Path.home() / ".agentic-coding-playbook"
 HOME_OVERRIDE_ENV = "AGENTIC_CODING_PLAYBOOK_HOME"
 CONTRACT_FILENAME = "AGENTS.md"
@@ -232,8 +232,8 @@ def ensure_contract(repo_root: Path, *, allow_fetch: bool = True) -> ContractRes
     stale_warning = (
         "Using a cached copy of the universal contract "
         f"({cache_path}). This is a fallback — the canonical way to provide it "
-        "is documented in the project README (agentic-coding-patterns sbx "
-        "mixin kit). Remove the cache once your environment provides the "
+        "is documented in the project README (agentic-coding-patterns acq "
+        "provisioning kit). Remove the cache once your environment provides the "
         "contract at the home path."
     )
 
@@ -279,6 +279,6 @@ def ensure_contract(repo_root: Path, *, allow_fetch: bool = True) -> ContractRes
             "Universal behavioral contract is NOT available and could not be "
             f"obtained. Expected at {home_path} (or the git-ignored cache). "
             "Do NOT proceed. Provide the contract per the project README "
-            "(agentic-coding-patterns sbx mixin kit), then retry."
+            "(agentic-coding-patterns acq provisioning kit), then retry."
         ),
     )

--- a/templates/AGENTS.md.template
+++ b/templates/AGENTS.md.template
@@ -58,8 +58,8 @@ proceeds — this project does **not** vendor a copy of them (to avoid drift).
 - **How it is provided:** the universal contract is made available by your
   environment at the conventional home path `~/.agentic-coding-playbook/AGENTS.md`
   (override with `$AGENTIC_CODING_PLAYBOOK_HOME`). See this project's README for
-  the supported setup (the `agentic-coding-patterns` sbx mixin kit). If the home
-  path is unavailable, a git-ignored fallback cache at
+  the supported setup (the `agentic-coding-patterns` `acq` provisioning kit). If
+  the home path is unavailable, a git-ignored fallback cache at
   `.agents/cache/AGENTS.universal.md` may be populated automatically.
 
 **Availability is a deterministic filesystem check — not a judgement call and

--- a/templates/contract-check.workflow.yaml
+++ b/templates/contract-check.workflow.yaml
@@ -29,7 +29,7 @@ jobs:
 
       # Provide the universal contract to the environment. Replace this step
       # with your organization's standard provisioning (e.g. the
-      # agentic-coding-patterns sbx mixin kit). The probe then verifies offline.
+      # agentic-coding-patterns acq provisioning kit). The probe then verifies offline.
       - name: Provision universal behavioral contract
         run: |
           mkdir -p "$HOME/.agentic-coding-playbook"


### PR DESCRIPTION
## Summary

The repo now supports multiple sandbox backends (`sbx`, `msb` [default], future `ppp`) via the `acq` wrapper, but docs/templates/runtime messages presented **sbx** as THE sandbox and the "sbx mixin kit" as THE provisioning path. Genericize to the neutral `acq` surface while keeping sbx as a named example, and allow for future backend growth (never hardcode the backend list).

## Change (10 coupling sites / 7 files)
- **CONTRIBUTING**: 'Working in SBX Containers' → 'Working in a Sandbox Backend'; `sbx exec` → `acq exec` (routes to the active backend), with a note to substitute a backend CLI (e.g. `sbx exec`) if calling one directly.
- **README**: 'the agentic-coding-patterns sbx mixin kit' → 'the `acq` provisioning kit' (selects sbx/msb; format supports adding more).
- **ensure_contract.py**: runtime fallback-warning + fail-closed halt strings + DEFAULT_HOME comment → 'acq provisioning kit'.
- **templates/AGENTS.md.template, examples/AGENTS.md.example, contract-check.workflow.yaml**, and the **generate-agents-md.py** source that emits the prerequisite text.
- **Stale path fix**: `integrations/isolation/sbx-kits` → `acq-kits` (patterns ADR-0001 renamed it; old path is a redirect shim being removed in Phase 4).

Left legitimately-sbx and cloud.gov-sandbox references as-is. Framing avoids hardcoding the backend set.

## Verification
500 tests pass; validate-docs, validate-adrs, generate-check green; ruff clean.

## Rollback
Revert. Docs/templates/comment strings + one stale path; no runtime behavior change.

Sibling of GSA-TTS/agentic-coding-quickstart#296 + GSA-TTS/agentic-coding-patterns#307. AI-assisted (OpenCode). Requires human review.