### PR TITLE
feat(meta): add CITATION.cff; stop calling the repo's own content 'guidance' (#214)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,49 @@
+# CITATION.cff — how to cite this repository.
+# Citation File Format v1.2.0 (https://citation-file-format.github.io/).
+# Root type is `software`: the repo ships a versioned, installable component
+# (the `playbook_validator` Python package + generators/validators + CLI, with
+# tagged releases). The practical practices and working examples it contains are
+# described in the abstract and keywords rather than as a separate root type,
+# because CFF 1.2.0 permits only one root type and tooling (GitHub "Cite this
+# repository", Zenodo, Zotero) renders it. Decided by multi-model consensus
+# (approved 4/0). This corpus is NOT federal "guidance" (a specific legal term);
+# it is practical, copy-and-use practices and working examples.
+cff-version: 1.2.0
+message: "If you reference or reuse this repository, please cite it as below."
+title: "Agentic Coding Playbook"
+abstract: >-
+  Practical practices and working examples for AI-assisted (agentic) software
+  development in federal environments: copy-and-use-verbatim patterns, a NIST
+  SP 800-53 control overlay for agentic AI systems, secure coding practices,
+  templates, checklists, and reference registries — plus the `playbook_validator`
+  tooling (generators and fail-closed validators) that keeps them consistent.
+  Built for cross-government reuse and contribution. This repository provides
+  informational best practices; it is not official policy or authoritative
+  federal guidance.
+type: software
+version: "0.14.1"
+license: CC0-1.0
+repository-code: "https://github.com/GSA-TTS/agentic-coding-playbook"
+url: "https://github.com/GSA-TTS/agentic-coding-playbook"
+keywords:
+  - agentic-coding
+  - ai-assisted-development
+  - federal
+  - secure-coding
+  - nist-800-53
+  - working-examples
+  - practices
+  - gsa-tts
+authors:
+  - name: "GSA Technology Transformation Services (GSA-TTS)"
+    website: "https://www.gsa.gov/tts"
+  - given-names: "William"
+    family-names: "Zujkowski"
+    email: "william.zujkowski@gsa.gov"
+    affiliation: "GSA Technology Transformation Services"
+    alias: "wz-gsa"
+  - given-names: "Bret"
+    family-names: "Mogilefsky"
+    email: "bret.mogilefsky@gsa.gov"
+    affiliation: "GSA Technology Transformation Services"
+    alias: "mogul"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,7 @@ make setup      # Install dependencies only
 
 Pre-commit hooks are **optional** for this repository. They are designed for **contributors** who are actively developing this project.
 
-**If you cloned this repo for guidance only** (to reference standards for your own projects), **you do not need to install the hooks**.
+**If you cloned this repo for reference only** (to copy patterns and standards into your own projects), **you do not need to install the hooks**.
 
 **If you are contributing to this repo**, you can opt-in to pre-commit hooks:
 

--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -22,7 +22,7 @@ frontmatter_schema:
   optional: ["audience", "contract", "frameworks", "keywords", "last_updated", "load_priority", "nist_controls", "related_files", "review_cycle", "stale_after"]
   status_values: ["canonical", "deprecated", "draft"]
   tier_values:
-    1: "Core guidance — authoritative rules and control mappings"
+    1: "Core — behavioral best practices, rules, and control mappings"
     2: "Supporting documentation — how-to guides and setup instructions"
     3: "Templates and checklists — reusable artifacts for projects"
   audience_values: ["all", "developers", "isso", "managers"]
@@ -31,7 +31,7 @@ frontmatter_schema:
 
 # Document inventory
 documents:
-  # ── Tier 1: Core Guidance ────────────────────────────────────────
+  # ── Tier 1: Core ─────────────────────────────────────────────────
   - path: "AGENTS.md"
     title: "Federal AI Agent Behavioral Best Practices"
     description: "Best practices for AI coding agent behavior in federal development environments — includes behavioral standards, engineering discipline enforcement, and verification requirements"

--- a/scripts/playbook_validator/generate_index.py
+++ b/scripts/playbook_validator/generate_index.py
@@ -32,7 +32,7 @@ _EXCLUDED_NAMES = {"CONTRIBUTING.md", "CHANGELOG.md", "README.md", "SECURITY.md"
 
 # Tier descriptions used in the YAML header
 _TIER_DESCRIPTIONS = {
-    1: "Core guidance — authoritative rules and control mappings",
+    1: "Core — behavioral best practices, rules, and control mappings",
     2: "Supporting documentation — how-to guides and setup instructions",
     3: "Templates and checklists — reusable artifacts for projects",
 }
@@ -298,7 +298,7 @@ def _render_documents(documents: list[DocumentInfo]) -> list[str]:
             tier_docs[doc.tier].append(doc)
 
     tier_headers = {
-        1: "  # ── Tier 1: Core Guidance ────────────────────────────────────────",
+        1: "  # ── Tier 1: Core ─────────────────────────────────────────────────",
         2: "  # ── Tier 2: Supporting Documentation ─────────────────────────────",
         3: "  # ── Tier 3: Templates, Checklists, and Examples ──────────────────",
     }


### PR DESCRIPTION
## Summary

Closes GSA-TTS/agentic-coding-playbook#214 (epic #208). Two related changes.

### 1. CITATION.cff (machine-citable)
Adds a CFF v1.2.0 file so GitHub renders a **"Cite this repository"** button (also consumed by Zenodo/Zotero).
- **Root `type: software`** — decided by **multi-model consensus (approved 4/0)**. The repo ships the versioned, installable `playbook_validator` package + generators/validators + CLI, released as tags; CFF permits only one root type, so the practices/working-examples corpus is described in `abstract` + `keywords`. (Consensus rejected `preferred-citation`/dataset-split as over-engineering for a small metadata file.)
- **authors:** GSA-TTS (org entity) + William Zujkowski (`wz-gsa`) + Bret Mogilefsky (`mogul`), per maintainer direction.
- `version: 0.14.1`, `license: CC0-1.0`.

### 2. Terminology accuracy — the repo's own content is not "guidance"
"Guidance" is a specific legal term, and the repo explicitly disclaims being authoritative federal guidance. The playbook is **practical, copy-and-use practices and working examples** for cross-government reuse. Fixed the **self-referential** uses:
- `generate_index`/INDEX tier-1 description: *"Core guidance — authoritative rules..."* → *"Core — behavioral best practices, rules, and control mappings"* (also drops the incorrect "authoritative", which contradicts the AGENTS.md disclaimer).
- The INDEX "Tier 1: Core Guidance" section header → "Tier 1: Core".
- CONTRIBUTING "cloned this repo for guidance only" → "for reference only".

**Left untouched** (legitimately "guidance"): the AGENTS.md disclaimer, citations to *external* federal guidance (NIST/OMB/CISA), and the `federal-ai-landscape` catalog (which correctly catalogs real guidance documents). The CITATION abstract keeps the honest disclaimer.

## Verification
| Check | Result |
|-------|--------|
| `pytest scripts/tests/` | 500 pass |
| CFF structure | validated (GitHub validates fully on push; renders "Cite this repository") |
| `validate-docs` / `generate-index --check` | green |
| `ruff check scripts/` | clean |
| residual self-referential "guidance" | none |

## Rollback
Revert. New metadata file + terminology strings + regenerated INDEX; no runtime/auth/data surface.

AI-assisted (OpenCode); consensus-reviewed (4/0 on the `type` decision). Requires human review.