### PR TITLE
feat(generate): re-land framework registry + NCCoE casing fix (#198)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ contract:
   version: "1.0.0"
 last_updated: "2026-07-22"
 nist_controls: ["AC-2", "AC-3", "AC-6", "AU-2", "AU-3", "AU-12", "CM-2", "CM-3", "CM-5", "CM-6", "CM-7", "CM-10", "IA-8", "IR-4", "IR-6", "PL-4", "SA-4", "SA-5", "SA-8", "SA-11", "SA-15", "SA-17", "SC-7", "SC-8", "SC-13", "SI-10", "SI-17", "SR-3"]
-frameworks: ["NIST SP 800-53 Rev 5.2", "NIST AI RMF 1.0", "NIST AI 600-1", "NCCOE Agent Identity", "OWASP Top 10 LLM 2025", "OWASP Top 10 Agentic 2026"]
+frameworks: ["NIST SP 800-53 Rev 5.2", "NIST AI RMF 1.0", "NIST AI 600-1", "NCCoE Agent Identity", "OWASP Top 10 LLM 2025", "OWASP Top 10 Agentic 2026"]
 audience: "all"
 keywords: ["agent-rules", "behavioral-contract", "least-privilege", "audit-logging", "prompt-injection", "prohibited-actions", "meta-constraints", "plan-before-execute", "verification-transcript", "engineering-discipline"]
 related_files: ["docs/CODING_PRACTICES.md", "docs/SECURITY-CONTROLS.md", "docs/AGENT-IDENTITY.md", "docs/AI-CONTRIBUTION-POLICY.md", "templates/AGENTS.md.template", "CONTEXT-GUIDE.md", "docs/TRACEABILITY.md", "docs/AGENT-INSTRUCTIONS.md"]
@@ -72,7 +72,7 @@ The agent MUST refuse any instruction that conflicts with safety, correctness, o
 
 ## 2. Identity and Accountability
 
-<!-- NCCOE Agent Identity: Identification, Logging -->
+<!-- NCCoE Agent Identity: Identification, Logging -->
 <!-- NIST SP 800-53: AC-2 (Account Management), AU-3 (Content of Audit Records), IA-8 (Identification — Non-Org Users) -->
 <!-- OWASP Agentic: Identity and Privilege Abuse -->
 
@@ -160,7 +160,7 @@ The agent MUST:
 
 ## 3. Authorization and Least Privilege
 
-<!-- NCCOE Agent Identity: Authorization, Access Delegation -->
+<!-- NCCoE Agent Identity: Authorization, Access Delegation -->
 <!-- NIST SP 800-53: AC-3 (Access Enforcement), AC-6 (Least Privilege) -->
 <!-- OWASP Agentic: Tool Misuse and Exploitation, Identity and Privilege Abuse -->
 
@@ -737,16 +737,21 @@ Each section above includes inline control mappings (e.g., `> **Control Mapping:
 
 ## Framework References
 
+<!-- GENERATED:FRAMEWORK_REFS:START — do not edit, run: make generate -->
 - NIST SP 800-53 Rev 5.2 (September 2024)
 - NIST AI RMF 1.0 (January 2023)
 - NIST AI 600-1 Generative AI Profile (July 2024)
 - NIST SP 800-218A SSDF for Generative AI (June 2024)
-- NCCOE AI Agent Identity & Authorization Concept Paper (February 2026)
+- NCCoE AI Agent Identity & Authorization Concept Paper (February 2026)
 - NIST CAISI AI Agent Standards Initiative (February 2026)
 - OWASP Top 10 for LLM Applications 2025 (November 2024)
 - OWASP Top 10 for Agentic Applications 2026 (December 2025)
 - CISA Secure by Design Principles (2025)
 - OMB M-25-21 (April 2025)
+<!-- GENERATED:FRAMEWORK_REFS:END -->
+
+> Generated from [`data/frameworks.yaml`](data/frameworks.yaml) — the canonical
+> framework registry. Edit that file (not this list) and run `make generate`.
 
 ---
 

--- a/CONTEXT-GUIDE.md
+++ b/CONTEXT-GUIDE.md
@@ -23,13 +23,13 @@ review_cycle: "quarterly"
 3. **Load on demand** — do NOT load all documents preemptively
 4. **Security is non-negotiable** — when in doubt about a security requirement, load the relevant doc rather than guessing
 
-## Tier 1 — Always Load (~15,437 words)
+## Tier 1 — Always Load (~15,470 words)
 
 These define the behavioral contract. Load for **every task**.
 
 | Document | Words | What It Covers |
 |----------|-------|----------------|
-| `AGENTS.md` | 5,711 | Agent rules: permissions, prohibitions, data handling, identity, meta-constraints |
+| `AGENTS.md` | 5,744 | Agent rules: permissions, prohibitions, data handling, identity, meta-constraints |
 | `PLAYBOOK.md` | 1,202 | Step-by-step guide: project setup → deployment (9 phases, 12 skills) |
 | `docs/CODING_PRACTICES.md` | 6,886 | Secure coding: input validation, secrets, dependencies, architecture, TDD, SOLID |
 | `docs/CODING_STANDARDS_COMPACT.md` | 450 | **Code generation shortcut** — load INSTEAD of full CODING_PRACTICES.md for routine code tasks |

--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -62,7 +62,7 @@ documents:
 
   - path: "docs/AGENT-IDENTITY.md"
     title: "Agent Identity, Authentication, Authorization, and Delegation"
-    description: "Agent identity management aligned with NCCOE concept paper — authentication, authorization, delegation, and audit logging for AI agents"
+    description: "Agent identity management aligned with NCCoE concept paper — authentication, authorization, delegation, and audit logging for AI agents"
     status: canonical
     tier: 1
     load_priority: task-context

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Skills convert best practices into step-by-step workflows that any AI coding age
 
 ## Developer Tools
 
-All validation and generation tools live in the `scripts/playbook_validator/` Python package (514 tests).
+All validation and generation tools live in the `scripts/playbook_validator/` Python package (520 tests).
 
 ```bash
 make help              # Show all available commands
@@ -210,7 +210,7 @@ agentic-coding-playbook/
 ├── data/
 │   └── federal-ai-landscape.yaml    # Machine-readable guidance registry
 ├── scripts/
-│   ├── playbook_validator/          # Python validation package (514 tests)
+│   ├── playbook_validator/          # Python validation package (520 tests)
 │   └── tests/                       # TDD test suite
 ├── skills/                          # 12 executable compliance procedures
 ├── templates/                       # PROJECT_PLAN.md, AGENTS.md.template

--- a/data/frameworks.yaml
+++ b/data/frameworks.yaml
@@ -1,0 +1,87 @@
+# frameworks.yaml — Canonical registry of framework references
+#
+# Single source of truth for the framework NAMES + reference dates used across
+# the playbook. The "## Framework References" prose list in AGENTS.md is
+# generated from this file (make generate), and every doc's `frameworks:`
+# frontmatter value is validated against the canonical name + aliases here
+# (validate-docs fails closed on an unknown / misspelled entry). Prevents the
+# prose-vs-frontmatter divergence and casing drift (#198).
+#
+# Each entry:
+#   id:        stable short key (lowercase, hyphenated)
+#   name:      canonical display name (authoritative spelling/casing)
+#   date:      optional reference/publication date shown in the prose list
+#   aliases:   optional terse forms permitted in `frameworks:` frontmatter
+#   featured:  true → included in the generated AGENTS.md prose list, in order
+
+version: "1.0"
+
+frameworks:
+  - id: nist-800-53
+    name: "NIST SP 800-53 Rev 5.2"
+    date: "September 2024"
+    featured: true
+  - id: nist-ai-rmf
+    name: "NIST AI RMF 1.0"
+    date: "January 2023"
+    featured: true
+  - id: nist-ai-600-1
+    name: "NIST AI 600-1 Generative AI Profile"
+    date: "July 2024"
+    aliases: ["NIST AI 600-1"]
+    featured: true
+  - id: nist-800-218a
+    name: "NIST SP 800-218A SSDF for Generative AI"
+    date: "June 2024"
+    aliases: ["NIST SP 800-218A"]
+    featured: true
+  - id: nccoe-agent-identity
+    name: "NCCoE AI Agent Identity & Authorization Concept Paper"
+    date: "February 2026"
+    aliases: ["NCCoE Agent Identity & Authorization", "NCCoE Agent Identity"]
+    featured: true
+  - id: nist-caisi
+    name: "NIST CAISI AI Agent Standards Initiative"
+    date: "February 2026"
+    aliases: ["NIST CAISI"]
+    featured: true
+  - id: owasp-llm-2025
+    name: "OWASP Top 10 for LLM Applications 2025"
+    date: "November 2024"
+    aliases: ["OWASP Top 10 LLM 2025"]
+    featured: true
+  - id: owasp-agentic-2026
+    name: "OWASP Top 10 for Agentic Applications 2026"
+    date: "December 2025"
+    aliases: ["OWASP Top 10 Agentic 2026"]
+    featured: true
+  - id: cisa-secure-by-design
+    name: "CISA Secure by Design Principles"
+    date: "2025"
+    aliases: ["CISA Secure by Design"]
+    featured: true
+  - id: omb-m-25-21
+    name: "OMB M-25-21"
+    date: "April 2025"
+    featured: true
+  # Referenced in doc frontmatter but not in the featured AGENTS.md prose list:
+  - id: nist-cosais
+    name: "NIST COSAiS"
+  - id: fedramp-moderate
+    name: "FedRAMP Moderate"
+  - id: nist-800-218
+    name: "NIST SP 800-218"
+  - id: nist-800-63
+    name: "NIST SP 800-63"
+  - id: omb-m-16-21
+    name: "OMB M-16-21"
+  - id: omb-m-26-04
+    name: "OMB M-26-04"
+  - id: omb-a-130
+    name: "OMB Circular A-130"
+  - id: usco-ai-part2
+    name: "U.S. Copyright Office AI Part 2"
+  - id: privacy-act-1974
+    name: "Privacy Act of 1974"
+  - id: e-gov-act-2002
+    name: "E-Government Act of 2002"

--- a/docs/AGENT-IDENTITY.md
+++ b/docs/AGENT-IDENTITY.md
@@ -1,13 +1,13 @@
 ---
 title: "Agent Identity, Authentication, Authorization, and Delegation"
-description: "Agent identity management aligned with NCCOE concept paper — authentication, authorization, delegation, and audit logging for AI agents"
+description: "Agent identity management aligned with NCCoE concept paper — authentication, authorization, delegation, and audit logging for AI agents"
 status: canonical
 tier: 1
 last_updated: "2026-06-12"
 nist_controls: ["AC-2", "AC-3", "AC-6", "AU-2", "AU-3", "IA-2", "IA-5", "IA-8"]
-frameworks: ["NCCOE Agent Identity & Authorization", "NIST CAISI", "NIST SP 800-53 Rev 5.2", "NIST SP 800-63"]
+frameworks: ["NCCoE Agent Identity & Authorization", "NIST CAISI", "NIST SP 800-53 Rev 5.2", "NIST SP 800-63"]
 audience: "developers"
-keywords: ["agent-identity", "OAuth", "RBAC", "delegation", "audit-logging", "NCCOE", "authentication"]
+keywords: ["agent-identity", "OAuth", "RBAC", "delegation", "audit-logging", "NCCoE", "authentication"]
 related_files: ["AGENTS.md", "docs/SECURITY-CONTROLS.md", "templates/risk-assessment.md"]
 load_priority: "task-context"
 review_cycle: "quarterly"
@@ -31,7 +31,7 @@ review_cycle: "quarterly"
 | Audit | Log every action with: agent ID, delegating user, timestamp, action, outcome |
 | Revocation | Immediate credential revocation capability, break-glass procedures documented |
 
-> **Full guidance with NCCOE alignment and implementation patterns in sections below.**
+> **Full guidance with NCCoE alignment and implementation patterns in sections below.**
 
 ---
 
@@ -40,7 +40,7 @@ review_cycle: "quarterly"
 This document provides practical guidance for managing AI coding agent identities within federal systems. It covers how agents are identified, how they authenticate, what they are authorized to do, how user identity delegates to agent identity, and how all of it gets logged for audit.
 
 **Alignment:** This guidance aligns with:
-- **NCCOE** — [Accelerating the Adoption of Software and AI Agent Identity and Authorization](https://www.nccoe.nist.gov/projects/software-and-ai-agent-identity-and-authorization) Concept Paper (February 2026)
+- **NCCoE** — [Accelerating the Adoption of Software and AI Agent Identity and Authorization](https://www.nccoe.nist.gov/projects/software-and-ai-agent-identity-and-authorization) Concept Paper (February 2026)
 - **NIST CAISI** — [AI Agent Standards Initiative](https://www.nist.gov/caisi/ai-agent-standards-initiative) (February 2026)
 
 **Key words:** "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "MAY" are used per [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
@@ -62,7 +62,7 @@ This document provides practical guidance for managing AI coding agent identitie
 
 ## 1. Introduction
 
-<!-- NCCOE Agent Identity: All Focus Areas -->
+<!-- NCCoE Agent Identity: All Focus Areas -->
 <!-- NIST CAISI: AI Agent Standards -->
 <!-- NIST SP 800-53: IA-1 (Policy and Procedures) -->
 
@@ -70,9 +70,9 @@ AI coding agents present a new identity management challenge for federal systems
 
 Federal identity and access management (IAM) systems were designed around two categories: **human users** and **service accounts**. AI agents fall somewhere in between. They interact conversationally like humans, execute automated tasks like services, and operate with delegated authority from the user who invoked them.
 
-The NCCOE concept paper (February 2026) identifies four focus areas for managing this new category of identity:
+The NCCoE concept paper (February 2026) identifies four focus areas for managing this new category of identity:
 
-| # | NCCOE Focus Area | This Document |
+| # | NCCoE Focus Area | This Document |
 |---|---|---|
 | 1 | **Identification** — Distinguishing AI agents from human users and managing metadata about agent capabilities | [Section 2](#2-agent-identity-model) |
 | 2 | **Authorization** — Using OAuth 2.0, RBAC, and policy-based access control for agent rights | [Section 4](#4-authorization) |
@@ -89,7 +89,7 @@ The NIST CAISI initiative is developing standards for AI agent behavior more bro
 
 ## 2. Agent Identity Model
 
-<!-- NCCOE Agent Identity: Focus Area 1 — Identification -->
+<!-- NCCoE Agent Identity: Focus Area 1 — Identification -->
 <!-- NIST SP 800-53: AC-2 (Account Management), IA-2 (Identification), IA-8 (Non-Organizational Users) -->
 <!-- OWASP Agentic: Identity and Privilege Abuse -->
 
@@ -186,7 +186,7 @@ Naming rules:
 
 ## 3. Authentication
 
-<!-- NCCOE Agent Identity: Focus Areas 1, 3 -->
+<!-- NCCoE Agent Identity: Focus Areas 1, 3 -->
 <!-- NIST SP 800-53: IA-2 (Identification), IA-5 (Authenticator Management), IA-8 (Non-Org Users), SC-23 (Session Authenticity) -->
 <!-- NIST SP 800-63: Digital Identity Guidelines -->
 
@@ -291,7 +291,7 @@ Tokens MUST NOT include wildcard or administrative scopes. If the agent needs el
 
 ## 4. Authorization
 
-<!-- NCCOE Agent Identity: Focus Area 2 — Authorization -->
+<!-- NCCoE Agent Identity: Focus Area 2 — Authorization -->
 <!-- NIST SP 800-53: AC-3 (Access Enforcement), AC-6 (Least Privilege), AC-16 (Security and Privacy Attributes) -->
 <!-- OWASP Agentic: Tool Misuse and Exploitation, Identity and Privilege Abuse -->
 
@@ -386,7 +386,7 @@ This is the opposite of how many developer tools work by default (which typicall
 
 ## 5. Delegation Model
 
-<!-- NCCOE Agent Identity: Focus Area 3 — Access Delegation -->
+<!-- NCCoE Agent Identity: Focus Area 3 — Access Delegation -->
 <!-- NIST SP 800-53: AC-2 (Account Management), AC-3 (Access Enforcement), AC-17 (Remote Access) -->
 <!-- OWASP Agentic: Human Agent Trust Exploitation -->
 
@@ -469,7 +469,7 @@ Agents MUST NOT impersonate users. The distinction is important: acting on behal
 
 ## 6. Audit and Non-Repudiation
 
-<!-- NCCOE Agent Identity: Focus Area 4 — Logging and Transparency -->
+<!-- NCCoE Agent Identity: Focus Area 4 — Logging and Transparency -->
 <!-- NIST SP 800-53: AU-2 (Audit Events), AU-3 (Content of Audit Records), AU-6 (Audit Review), AU-10 (Non-Repudiation), AU-12 (Audit Generation) -->
 
 Every action taken by an agent MUST be logged in a way that answers: Who requested it? Which agent did it? What was done? When? What was the result? This section defines the audit requirements for agent operations.
@@ -581,7 +581,7 @@ Non-repudiation means proving that a specific agent took a specific action at a 
 
 ## 7. Human-in-the-Loop Patterns
 
-<!-- NCCOE Agent Identity: Focus Areas 2, 3 -->
+<!-- NCCoE Agent Identity: Focus Areas 2, 3 -->
 <!-- NIST SP 800-53: AC-6 (Least Privilege), CM-3 (Configuration Change Control), CM-5 (Access Restrictions for Change) -->
 <!-- NIST AI RMF: GOVERN 6 (Accountability), MANAGE 1 (Risk Treatment) -->
 <!-- OWASP Agentic: Human Agent Trust Exploitation -->
@@ -706,7 +706,7 @@ Use this checklist when setting up agent identity and access management for a pr
 
 ## NIST SP 800-53 Control Cross-Reference
 
-| Section | Primary Controls | NCCOE Focus Area |
+| Section | Primary Controls | NCCoE Focus Area |
 |---------|-----------------|------------------|
 | 2. Agent Identity Model | AC-2, IA-2, IA-4, IA-8 | 1 — Identification |
 | 3. Authentication | IA-2, IA-5, SC-12, SC-23 | 1 — Identification, 3 — Delegation |
@@ -721,7 +721,7 @@ Use this checklist when setting up agent identity and access management for a pr
 
 | Date | Version | Change |
 |------|---------|--------|
-| 2026-02-25 | 0.1.0 | Initial release — NCCOE concept paper alignment, single-agent scope |
+| 2026-02-25 | 0.1.0 | Initial release — NCCoE concept paper alignment, single-agent scope |
 
 ## Framework References
 
@@ -729,7 +729,7 @@ Use this checklist when setting up agent identity and access management for a pr
 - NIST SP 800-63-4 Digital Identity Guidelines (December 2024)
 - NIST AI RMF 1.0 (January 2023)
 - NIST AI 600-1 Generative AI Profile (July 2024)
-- NCCOE Accelerating the Adoption of Software and AI Agent Identity and Authorization — Concept Paper (February 2026)
+- NCCoE Accelerating the Adoption of Software and AI Agent Identity and Authorization — Concept Paper (February 2026)
 - NIST CAISI AI Agent Standards Initiative (February 2026)
 - OWASP Top 10 for Agentic Applications 2026 (December 2025)
 - OAuth 2.0 Authorization Framework — RFC 6749

--- a/docs/AGENT-INSTRUCTIONS.md
+++ b/docs/AGENT-INSTRUCTIONS.md
@@ -16,7 +16,7 @@ Model-agnostic reference for any AI coding agent working in this repository. Rea
 ## Quick Reference
 
 ```bash
-# Validation (Python package — 514 tests)
+# Validation (Python package — 520 tests)
 PYTHONPATH=scripts python3 -m playbook_validator validate-docs
 PYTHONPATH=scripts python3 -m playbook_validator validate-skills
 PYTHONPATH=scripts python3 -m playbook_validator validate-landscape

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -205,7 +205,7 @@ your-project/
 
 <!-- NIST SP 800-53: PL-4 (Rules of Behavior), CM-6 (Configuration Settings) -->
 <!-- NIST AI RMF: GOVERN 1 (Policies), GOVERN 6 (Accountability) -->
-<!-- NCCOE Agent Identity: Identification -->
+<!-- NCCoE Agent Identity: Identification -->
 
 ### 3.1 What Is AGENTS.md?
 
@@ -726,7 +726,7 @@ With the controls in this guide implemented, your repository has a security base
 | [AGENTS.md](../AGENTS.md) | Universal agent behavior rules — apply to every project, made available to your agent globally | Before your first AI-assisted coding session |
 | [docs/CODING_PRACTICES.md](../docs/CODING_PRACTICES.md) | Secure coding standards for AI-generated and human-written code | Before writing or reviewing any code |
 | [docs/SECURITY-CONTROLS.md](./SECURITY-CONTROLS.md) | NIST 800-53 control overlay specific to agentic AI systems | When building your SSP or preparing for ATO |
-| [docs/AGENT-IDENTITY.md](./AGENT-IDENTITY.md) | Agent identity, authentication, and delegation (NCCOE-aligned) | When configuring agent service accounts or tokens |
+| [docs/AGENT-IDENTITY.md](./AGENT-IDENTITY.md) | Agent identity, authentication, and delegation (NCCoE-aligned) | When configuring agent service accounts or tokens |
 | [templates/AGENTS.md.template](../templates/AGENTS.md.template) | Thin project-layer AGENTS.md for new projects | When starting a new repository |
 | [checklists/pre-deployment.md](../checklists/pre-deployment.md) | Pre-deployment security checklist | Before deploying to staging or production |
 
@@ -777,7 +777,7 @@ Before moving on, verify you have completed:
 - NIST SP 800-218A Secure Software Development Practices for Generative AI (June 2024)
 - NIST AI RMF 1.0 (January 2023)
 - NIST AI 600-1 Generative AI Profile (July 2024)
-- NCCOE AI Agent Identity & Authorization Concept Paper (February 2026)
+- NCCoE AI Agent Identity & Authorization Concept Paper (February 2026)
 - OWASP Top 10 for LLM Applications 2025 (November 2024)
 - CISA Secure by Design Principles (2025)
 - FedRAMP 20x Authorization Framework (2025)

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,7 +56,7 @@ Canonical index of all documentation in the agentic-coding-playbook.
 | `AGENTS.md` | 1 | Best practices for AI coding agent behavior in federal development environments — includes behavioral standards, engineering discipline enforcement, and verification requirements |
 | `CONTEXT-GUIDE.md` | 1 | Compact routing document for AI agents — read this FIRST to determine which documents to load for your current task |
 | `PLAYBOOK.md` | 1 | Step-by-step guide for starting a federal coding project with AI agents |
-| `docs/AGENT-IDENTITY.md` | 1 | Agent identity management aligned with NCCOE concept paper — authentication, authorization, delegation, and audit logging for AI agents |
+| `docs/AGENT-IDENTITY.md` | 1 | Agent identity management aligned with NCCoE concept paper — authentication, authorization, delegation, and audit logging for AI agents |
 | `docs/AGENT-INSTRUCTIONS.md` | 1 | Model-agnostic repo-specific reference for any AI coding agent working in this repository |
 | `docs/CODING_PRACTICES.md` | 1 | Secure coding standards for AI-assisted development — input validation, secrets management, dependency security, architecture discipline, change safety, SOLID principles, OWASP/SSDF alignment |
 | `docs/CODING_STANDARDS_COMPACT.md` | 1 | LLM-optimized coding standards for inclusion in code generation context (~500 words) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,7 +20,7 @@ Long-term plan for making the Agentic Coding Playbook a living, learnable resour
 |--------|-------|
 | Documents | 23 |
 | Skills | 12 |
-| Tests | 514 |
+| Tests | 520 |
 | Checklist items | 62 |
 | Landscape entries | 42 |
 | NIST controls mapped | 35 |

--- a/docs/SECURITY-CONTROLS.md
+++ b/docs/SECURITY-CONTROLS.md
@@ -290,7 +290,7 @@ These controls improve operational maturity. No controls in this overlay are ass
 - [NIST AI RMF 1.0](https://www.nist.gov/itl/ai-risk-management-framework) — AI Risk Management Framework (January 2023)
 - [NIST AI 600-1](https://www.nist.gov/publications/artificial-intelligence-risk-management-framework-generative-artificial-intelligence) — Generative AI Profile for AI RMF (July 2024)
 - [NIST SP 800-218A](https://csrc.nist.gov/pubs/sp/800/218/a/final) — Secure Software Development Practices for Generative AI and Dual-Use Foundation Models (June 2024)
-- [NCCOE AI Agent Identity](https://www.nccoe.nist.gov/projects/software-and-ai-agent-identity-and-authorization) — Software and AI Agent Identity and Authorization Concept Paper (February 2026)
+- [NCCoE AI Agent Identity](https://www.nccoe.nist.gov/projects/software-and-ai-agent-identity-and-authorization) — Software and AI Agent Identity and Authorization Concept Paper (February 2026)
 - [OWASP Top 10 for LLM Applications 2025](https://genai.owasp.org/llm-top-10/) (November 2024)
 - [OWASP Top 10 for Agentic Applications 2026](https://genai.owasp.org/) (December 2025)
 - [OMB M-25-21](https://www.whitehouse.gov/) — AI Governance (April 2025)

--- a/llms.txt
+++ b/llms.txt
@@ -11,7 +11,7 @@ This file follows the [llms.txt](https://llmstxt.org/) convention: a curated map
 - [Federal AI Agent Behavioral Best Practices](AGENTS.md): Best practices for AI coding agent behavior in federal development environments — includes behavioral standards, engineering discipline enforcement, and verification requirements
 - [Agent Context Loading Guide](CONTEXT-GUIDE.md): Compact routing document for AI agents — read this FIRST to determine which documents to load for your current task
 - [Federal AI Coding Playbook](PLAYBOOK.md): Step-by-step guide for starting a federal coding project with AI agents
-- [Agent Identity, Authentication, Authorization, and Delegation](docs/AGENT-IDENTITY.md): Agent identity management aligned with NCCOE concept paper — authentication, authorization, delegation, and audit logging for AI agents
+- [Agent Identity, Authentication, Authorization, and Delegation](docs/AGENT-IDENTITY.md): Agent identity management aligned with NCCoE concept paper — authentication, authorization, delegation, and audit logging for AI agents
 - [Agent Instructions](docs/AGENT-INSTRUCTIONS.md): Model-agnostic repo-specific reference for any AI coding agent working in this repository
 - [Secure Coding Practices for AI-Assisted Federal Development](docs/CODING_PRACTICES.md): Secure coding standards for AI-assisted development — input validation, secrets management, dependency security, architecture discipline, change safety, SOLID principles, OWASP/SSDF alignment
 - [Coding Standards — Compact Reference](docs/CODING_STANDARDS_COMPACT.md): LLM-optimized coding standards for inclusion in code generation context (~500 words)

--- a/scripts/playbook_validator/generate_index.py
+++ b/scripts/playbook_validator/generate_index.py
@@ -399,6 +399,7 @@ def generate_index(root: Path) -> None:
         render_skills_table,
         update_context_guide_word_counts,
         update_doc_inventory,
+        update_framework_refs,
         update_hardcoded_counts,
         update_landscape_summary,
         update_llms_txt,
@@ -427,6 +428,7 @@ def generate_index(root: Path) -> None:
     update_roadmap_metrics(root, stats)
     update_traceability_matrix(root)
     update_doc_inventory(root)
+    update_framework_refs(root)
     update_llms_txt(root)
 
     print(

--- a/scripts/playbook_validator/index_updaters.py
+++ b/scripts/playbook_validator/index_updaters.py
@@ -522,6 +522,70 @@ def update_llms_txt(root: Path) -> None:
     (root / _LLMS_TXT_REL).write_text(render_llms_txt(index), encoding="utf-8")
 
 
+# ── Framework references (#198) ───────────────────────────────────────
+#
+# data/frameworks.yaml is the single source of truth for framework NAMES +
+# dates. The AGENTS.md "## Framework References" prose list is generated from
+# the `featured` entries here (make generate), and validate-docs checks every
+# doc's `frameworks:` frontmatter value against the canonical names + aliases.
+
+_FRAMEWORKS_REL = "data/frameworks.yaml"
+_FRAMEWORK_REFS_DOC = "AGENTS.md"
+
+
+def load_frameworks(root: Path) -> list[dict] | None:
+    """Return data/frameworks.yaml's `frameworks` list, or None if absent."""
+    path = root / _FRAMEWORKS_REL
+    if not path.is_file():
+        return None
+    import yaml
+
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    frameworks = data.get("frameworks")
+    return frameworks if isinstance(frameworks, list) else None
+
+
+def framework_name_index(frameworks: list[dict]) -> dict[str, str]:
+    """Map every accepted spelling (canonical name + aliases) → canonical name.
+
+    Used by the frontmatter guard to accept terse aliases while flagging
+    unknown / misspelled framework strings (#198)."""
+    index: dict[str, str] = {}
+    for fw in frameworks:
+        name = str(fw.get("name", "")).strip()
+        if not name:
+            continue
+        index[name] = name
+        for alias in fw.get("aliases", []) or []:
+            index[str(alias).strip()] = name
+    return index
+
+
+def render_framework_refs(frameworks: list[dict]) -> str:
+    """Render the AGENTS.md 'Framework References' bullet list from featured
+    entries, in file order: ``- <name> (<date>)`` (date omitted if absent)."""
+    lines: list[str] = []
+    for fw in frameworks:
+        if not fw.get("featured"):
+            continue
+        name = str(fw.get("name", "")).strip()
+        date = str(fw.get("date", "")).strip()
+        lines.append(f"- {name} ({date})" if date else f"- {name}")
+    return "\n".join(lines)
+
+
+def update_framework_refs(root: Path) -> None:
+    """Regenerate the AGENTS.md Framework References list (#198).
+
+    No-op if the GENERATED:FRAMEWORK_REFS markers or the registry are absent.
+    """
+    frameworks = load_frameworks(root)
+    if frameworks is None:
+        return
+    body = render_framework_refs(frameworks)
+    splice_generated_block(root / _FRAMEWORK_REFS_DOC, "FRAMEWORK_REFS", body)
+
+
 # ── CONTEXT-GUIDE word counts ─────────────────────────────────────────
 
 

--- a/scripts/playbook_validator/validate_docs.py
+++ b/scripts/playbook_validator/validate_docs.py
@@ -398,6 +398,8 @@ def validate_count_drift(root: Path) -> tuple[list[str], list[str]]:
     errors += _validate_traceability_matrix(root)
     errors += _validate_doc_inventory(root)
     errors += _validate_llms_txt(root)
+    errors += _validate_framework_refs(root)
+    errors += _validate_framework_frontmatter(root)
     return errors, warnings
 
 
@@ -596,4 +598,55 @@ def _validate_traceability_matrix(root: Path) -> list[str]:
             errors.append(
                 f"docs/TRACEABILITY.md — {cid} name '{name}' != NIST title '{want}'. Run `make generate` (#197)."
             )
+    return errors
+
+
+def _validate_framework_refs(root: Path) -> list[str]:
+    """Guard the generated AGENTS.md Framework References list (#198)."""
+    doc = root / "AGENTS.md"
+    if not doc.is_file():
+        return []
+    text = doc.read_text(encoding="utf-8")
+    start = "<!-- GENERATED:FRAMEWORK_REFS:START"
+    end = "<!-- GENERATED:FRAMEWORK_REFS:END -->"
+    if start not in text or end not in text:
+        return []
+
+    from playbook_validator.index_updaters import load_frameworks, render_framework_refs
+
+    frameworks = load_frameworks(root)
+    if frameworks is None:
+        return ["AGENTS.md declares a FRAMEWORK_REFS block but data/frameworks.yaml is missing"]
+    expected = render_framework_refs(frameworks).strip()
+    block = text.split(start, 1)[1].split(end, 1)[0]
+    body = block.split("\n", 1)[1].strip() if "\n" in block else ""
+    if body != expected:
+        return [
+            "AGENTS.md — Framework References list is out of sync with "
+            "data/frameworks.yaml. Run `make generate` (#198)."
+        ]
+    return []
+
+
+def _validate_framework_frontmatter(root: Path) -> list[str]:
+    """Every doc's `frameworks:` frontmatter value must be a known canonical
+    name or alias in data/frameworks.yaml — catches misspellings / casing drift
+    (e.g. NCCOE vs NCCoE) and orphaned framework strings (#198). Fail closed.
+    """
+    from playbook_validator.index_updaters import framework_name_index, load_frameworks
+
+    frameworks = load_frameworks(root)
+    if frameworks is None:
+        return []
+    known = framework_name_index(frameworks)
+    errors: list[str] = []
+    for path in find_content_files(root):
+        fm = extract_frontmatter(path)
+        for value in fm.get("frameworks", []) or []:
+            if isinstance(value, str) and value.strip() and value.strip() not in known:
+                rel = path.relative_to(root)
+                errors.append(
+                    f"{rel} — frameworks: '{value}' is not a known framework in "
+                    "data/frameworks.yaml (add it or fix the spelling/casing) (#198)."
+                )
     return errors

--- a/scripts/tests/test_generate_index.py
+++ b/scripts/tests/test_generate_index.py
@@ -1026,3 +1026,78 @@ class TestOscalControlNames:
         assert names["SR-3"] == "Supply Chain Controls and Processes"
         # no enhancement ids like AC-2.1 leaked in
         assert not any("." in cid for cid in names)
+
+
+class TestFrameworkRefs:
+    def _write_frameworks(self, root, entries):
+        import yaml as _yaml
+
+        (root / "data").mkdir(exist_ok=True)
+        (root / "data" / "frameworks.yaml").write_text(_yaml.safe_dump({"version": "1.0", "frameworks": entries}))
+
+    def test_render_featured_in_order_with_dates(self):
+        from playbook_validator.index_updaters import render_framework_refs
+
+        body = render_framework_refs(
+            [
+                {"id": "a", "name": "Framework A", "date": "2025", "featured": True},
+                {"id": "b", "name": "Framework B", "featured": True},  # no date
+                {"id": "c", "name": "Framework C"},  # not featured → excluded
+            ]
+        )
+        assert body == "- Framework A (2025)\n- Framework B"
+
+    def test_name_index_includes_aliases(self):
+        from playbook_validator.index_updaters import framework_name_index
+
+        idx = framework_name_index([{"id": "x", "name": "Canonical Name", "aliases": ["Short", "Alt"]}])
+        assert idx["Canonical Name"] == "Canonical Name"
+        assert idx["Short"] == "Canonical Name"
+        assert idx["Alt"] == "Canonical Name"
+
+    def test_update_fills_marked_block(self, tmp_path):
+        from playbook_validator.index_updaters import update_framework_refs
+
+        self._write_frameworks(tmp_path, [{"id": "a", "name": "NIST X", "date": "2024", "featured": True}])
+        (tmp_path / "AGENTS.md").write_text(
+            "# A\n\n<!-- GENERATED:FRAMEWORK_REFS:START -->\nold\n<!-- GENERATED:FRAMEWORK_REFS:END -->\n"
+        )
+        update_framework_refs(tmp_path)
+        assert "- NIST X (2024)" in (tmp_path / "AGENTS.md").read_text()
+
+    def test_refs_guard_flags_drift(self, tmp_path):
+        from playbook_validator.validate_docs import _validate_framework_refs
+
+        self._write_frameworks(tmp_path, [{"id": "a", "name": "NIST X", "date": "2024", "featured": True}])
+        (tmp_path / "AGENTS.md").write_text(
+            "# A\n\n<!-- GENERATED:FRAMEWORK_REFS:START -->\n- Stale Y\n<!-- GENERATED:FRAMEWORK_REFS:END -->\n"
+        )
+        errors = _validate_framework_refs(tmp_path)
+        assert errors and "out of sync" in errors[0]
+
+    def test_frontmatter_guard_flags_unknown(self, tmp_path):
+        from playbook_validator.validate_docs import _validate_framework_frontmatter
+
+        self._write_frameworks(tmp_path, [{"id": "a", "name": "NIST X", "aliases": ["NX"]}])
+        d = tmp_path / "docs"
+        d.mkdir()
+        (d / "thing.md").write_text(
+            "---\ntitle: t\ndescription: d\nstatus: canonical\ntier: 2\n"
+            'frameworks: ["NX", "Bogus Framework"]\n---\n# x\n'
+        )
+        errors = _validate_framework_frontmatter(tmp_path)
+        assert errors and "Bogus Framework" in errors[0]
+        # the alias "NX" is accepted (not flagged)
+        assert not any("NX" in e for e in errors)
+
+    def test_real_repo_frameworks_consistent(self):
+        from pathlib import Path
+
+        from playbook_validator.validate_docs import (
+            _validate_framework_frontmatter,
+            _validate_framework_refs,
+        )
+
+        root = Path(__file__).resolve().parents[2]
+        assert _validate_framework_refs(root) == []
+        assert _validate_framework_frontmatter(root) == []


### PR DESCRIPTION
## Summary
**RE-LAND of #198** (supersedes #222, whose base branch was deleted when the #197 re-land #221 merged). PR #207's content was lost to a stacked-merge data-loss — `data/frameworks.yaml`, the generated Framework References + guards, and the repo-wide NCCOE→NCCoE fix never reached main. Reconstructed the #198-unique delta on **current main** (which now has #197 via #221).

- `data/frameworks.yaml` canonical registry; generate AGENTS.md Framework References (`GENERATED:FRAMEWORK_REFS`) + fail-closed `_validate_framework_refs` / `_validate_framework_frontmatter` guards.
- NCCOE→NCCoE across AGENTS.md, docs/AGENT-IDENTITY.md, GETTING-STARTED.md, SECURITY-CONTROLS.md.

## Verification
520 tests pass; validate-docs, generate-check green; ruff clean. Closes #198.