### PR TITLE
docs(a11y): Section 508 accessibility statement + markdown hygiene (#211)

### DIFF
--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -1,0 +1,59 @@
+# Accessibility Statement
+
+The Agentic Coding Playbook is committed to accessibility as a federal
+obligation under **Section 508 of the Rehabilitation Act** and the **21st
+Century Integrated Digital Experience Act (21st Century IDEA)**. This statement
+covers the accessibility of **this repository's own content** (its Markdown
+documentation). Guidance for making the *software you build* accessible lives in
+[`docs/CODING_PRACTICES.md` §14 (Accessibility)](docs/CODING_PRACTICES.md).
+
+## Scope
+
+This repository is a documentation and tooling corpus consumed as Markdown on
+GitHub, in editors, and by AI agents. There is no hosted web UI, so
+accessibility here means **accessible document structure**: content that screen
+readers, keyboard navigation, and assistive tooling can parse reliably.
+
+## What we do
+
+Every Markdown document in this repository is expected to:
+
+- **Start with a single top-level heading (H1)** and use properly nested
+  heading levels — the primary navigation landmark for assistive technology.
+- **Provide alternative text for every image** (`![descriptive text](path)`;
+  decorative images use `alt=""`). Enforced by markdownlint **MD045** in CI and
+  pre-commit.
+- **Use real Markdown tables with header rows** (GFM tables require a header +
+  separator row to render), so tabular data is announced with column context.
+- **Prefer plain language and descriptive link text** ("see the contributing
+  guide", not "click here"), per [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+The image alt-text rule runs in CI (`markdownlint-cli2`) and pre-commit, so that
+regression fails the build rather than shipping. Heading structure, table
+headers, and link text are contributor conventions reinforced in review.
+
+## What we ask of contributors
+
+When adding or editing documentation:
+
+1. Give the document one H1 and nest sub-headings without skipping levels.
+2. Add meaningful `alt` text to any image; use `alt=""` only for purely
+   decorative images.
+3. Keep tables real Markdown tables with a header row — don't fake them with
+   spacing.
+4. Write descriptive link text and plain language.
+
+Run `make lint` (or let pre-commit run) before opening a pull request.
+
+## Reporting an accessibility issue
+
+If you find a documentation-accessibility problem in this repository, open a
+GitHub issue. For accessibility of a GSA service or website (not this repo), see
+the [GSA Section 508 program](https://www.section508.gov/).
+
+## References
+
+- [Section 508 program (section508.gov)](https://www.section508.gov/)
+- [WCAG 2.1](https://www.w3.org/TR/WCAG21/)
+- [`docs/CODING_PRACTICES.md` §14](docs/CODING_PRACTICES.md) — accessibility of
+  software the playbook advises on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,20 @@ The simplest approach:
 - **Provide actionable examples** — show what to do, not just what the standard says
 - **Include control mappings** — every section should reference applicable NIST 800-53 controls
 
+### Accessibility & Markdown Hygiene
+
+Documentation in this repository must be **accessible** (Section 508 — see
+[ACCESSIBILITY.md](ACCESSIBILITY.md)). When adding or editing docs:
+
+- Start each document with a single top-level heading (H1) and nest sub-headings
+  without skipping levels.
+- Give every image meaningful `alt` text; use `alt=""` only for decorative
+  images (enforced by markdownlint **MD045**).
+- Keep tables as real Markdown tables with a header row.
+- Use descriptive link text and plain language.
+
+`make lint` (and pre-commit) run the image alt-text check; it also runs in CI.
+
 ### What We Need
 
 - **Practitioner feedback** — Does this playbook work in your agency's environment?

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ We welcome contributions from the federal agentic-coding community.
 - **Questions** — Open a GitHub issue or start a discussion
 - **Not sure how?** — Open an issue to discuss
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for details. This project uses [conventional commits](https://www.conventionalcommits.org/) and automated releases via [release-please](https://github.com/googleapis/release-please).
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for details. This project uses [conventional commits](https://www.conventionalcommits.org/) and automated releases via [release-please](https://github.com/googleapis/release-please). Documentation follows our [accessibility statement](./ACCESSIBILITY.md) (Section 508).
 
 ### Share What You Learn
 

--- a/scripts/playbook_validator/validate_docs.py
+++ b/scripts/playbook_validator/validate_docs.py
@@ -34,6 +34,7 @@ EXCLUDED_FILENAMES = frozenset(
         "CODE_OF_CONDUCT.md",
         "SUPPORT.md",
         "GOVERNANCE.md",
+        "ACCESSIBILITY.md",
         "LICENSE",
         "TRANSFER.md",
     }


### PR DESCRIPTION
## Summary
Closes #211 (epic #208). Per your scope decision — **repo-level statement + lint, not per-doc frontmatter**.

- **NEW `ACCESSIBILITY.md`**: the repository's own Section 508 posture — accessible Markdown structure (H1/heading nesting, image alt text, real table headers, plain language + descriptive link text), how it's enforced, and how to report an issue. Explicitly distinguishes *repo-doc* accessibility from the *application* accessibility guidance already in `docs/CODING_PRACTICES.md §14`.
- **CONTRIBUTING**: new 'Accessibility & Markdown Hygiene' subsection.
- **README**: links the statement from Contributing.

## Enforcement (reuse, don't reinvent)
- **Image alt text** is enforced by the **existing markdownlint MD045**, already ON and green in CI + pre-commit.
- **MD041 (first-line-H1) evaluated and NOT enabled**: it false-positives on our YAML-frontmatter docs (flags the `---` line on 62 files that already have proper H1s). Heading structure stays a reviewed convention. No redundant Python hygiene check was added — markdownlint is the right tool and is already wired in.
- `ACCESSIBILITY.md` added to `validate_docs` EXCLUDED_FILENAMES (root meta-file, like README/SECURITY).

## Verification
markdownlint **0 errors**; validate-docs + generate-check green; **520 tests**; ruff clean.

## Rollback
Revert. New doc + two doc edits + one exclusion-list entry; no runtime/code-behavior change.

AI-assisted (OpenCode). Requires human review.