### PR TITLE
fix(landscape): make FEDERAL-AI-LANDSCAPE.md freshness date evergreen from the registry

### DIFF
--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -7,10 +7,10 @@
 # before making changes that span multiple documents.
 #
 # Schema version: 1.0
-# Last generated: 2026-08-11
+# Last generated: 2026-08-14
 
 schema_version: "1.0"
-generated: "2026-08-11"
+generated: "2026-08-14"
 repo: "GSA-TTS/agentic-coding-playbook"
 scope: "FIPS Moderate | Single-agent | Internal enterprise"
 
@@ -138,8 +138,9 @@ documents:
     status: canonical
     tier: 2
     load_priority: on-demand
-    last_updated: "2026-06-29"
+    last_updated: "2026-08-04"
     audience: [developers, isso, managers, agents]
+    review_cycle: quarterly
 
   - path: "docs/GETTING-STARTED.md"
     title: "Getting Started: Repository Setup and Environment Hardening"

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Skills convert best practices into step-by-step workflows that any AI coding age
 
 ## Developer Tools
 
-All validation and generation tools live in the `scripts/playbook_validator/` Python package (520 tests).
+All validation and generation tools live in the `scripts/playbook_validator/` Python package (527 tests).
 
 ```bash
 make help              # Show all available commands
@@ -212,7 +212,7 @@ agentic-coding-playbook/
 ├── data/
 │   └── federal-ai-landscape.yaml    # Machine-readable guidance registry
 ├── scripts/
-│   ├── playbook_validator/          # Python validation package (520 tests)
+│   ├── playbook_validator/          # Python validation package (527 tests)
 │   └── tests/                       # TDD test suite
 ├── skills/                          # 12 executable compliance procedures
 ├── templates/                       # PROJECT_PLAN.md, AGENTS.md.template

--- a/data/federal-ai-landscape.yaml
+++ b/data/federal-ai-landscape.yaml
@@ -5,7 +5,10 @@
 # Statuses: active, revoked, rescinded, draft, final
 #
 # This file is the single source of truth. docs/FEDERAL-AI-LANDSCAPE.md is generated from it.
-# Last reviewed: 2026-04-06
+# `last_reviewed` below is the canonical review date; `make generate` propagates it into the
+# doc's frontmatter + "Last reviewed" line. The discovery/update path advances it only when
+# the entries actually change (see bump_landscape_reviewed_if_changed). Do not hand-edit the
+# date in the doc — edit it here.
 
 version: "1.0"
 last_reviewed: "2026-08-04"

--- a/docs/AGENT-INSTRUCTIONS.md
+++ b/docs/AGENT-INSTRUCTIONS.md
@@ -16,7 +16,7 @@ Model-agnostic reference for any AI coding agent working in this repository. Rea
 ## Quick Reference
 
 ```bash
-# Validation (Python package — 520 tests)
+# Validation (Python package — 527 tests)
 PYTHONPATH=scripts python3 -m playbook_validator validate-docs
 PYTHONPATH=scripts python3 -m playbook_validator validate-skills
 PYTHONPATH=scripts python3 -m playbook_validator validate-landscape

--- a/docs/FEDERAL-AI-LANDSCAPE.md
+++ b/docs/FEDERAL-AI-LANDSCAPE.md
@@ -3,20 +3,23 @@ title: "Federal AI Landscape"
 description: "Canonical catalog of federal AI guidance, executive orders, standards, and legislation relevant to AI-assisted software development"
 status: canonical
 tier: 2
-last_updated: "2026-06-29"
+last_updated: "2026-08-04"
 load_priority: on-demand
 audience: ["developers", "isso", "managers", "agents"]
 keywords: ["federal", "AI", "guidance", "executive order", "NIST", "OMB", "OWASP", "compliance", "legislation"]
-last_reviewed: "2026-06-29"
+last_reviewed: "2026-08-04"
+review_cycle: "quarterly"
 ---
 
 # Federal AI Landscape
 
 Canonical reference for all federal AI guidance relevant to AI-assisted software development. Each entry includes current status, relevance to this playbook, and official source URL.
 
-> **Last reviewed:** 2026-06-29. Federal AI policy is evolving rapidly. Verify status before citing in compliance documents.
+<!-- GENERATED:LANDSCAPE_REVIEWED:START — do not edit, run: make generate -->
+> **Last reviewed:** 2026-08-04. Federal AI policy is evolving rapidly. Verify status before citing in compliance documents.
+<!-- GENERATED:LANDSCAPE_REVIEWED:END -->
 >
-> **Machine-readable data:** [`data/federal-ai-landscape.yaml`](../data/federal-ai-landscape.yaml) — structured registry with IDs, dates, statuses, cross-references, and compliance deadlines. Use the YAML for programmatic access; this document is the human-readable companion.
+> **Machine-readable data:** [`data/federal-ai-landscape.yaml`](../data/federal-ai-landscape.yaml) — structured registry with IDs, dates, statuses, cross-references, and compliance deadlines. Use the YAML for programmatic access; this document is the human-readable companion. The "Last reviewed" date, the counts, and the tables above/below are generated from that file by `make generate` — edit the YAML, not this doc.
 
 ## Status Summary
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,7 +20,7 @@ Long-term plan for making the Agentic Coding Playbook a living, learnable resour
 |--------|-------|
 | Documents | 23 |
 | Skills | 12 |
-| Tests | 520 |
+| Tests | 527 |
 | Checklist items | 62 |
 | Landscape entries | 42 |
 | NIST controls mapped | 35 |

--- a/scripts/playbook_validator/generate_index.py
+++ b/scripts/playbook_validator/generate_index.py
@@ -401,6 +401,7 @@ def generate_index(root: Path) -> None:
         update_doc_inventory,
         update_framework_refs,
         update_hardcoded_counts,
+        update_landscape_reviewed,
         update_landscape_summary,
         update_llms_txt,
         update_phase_mapping,
@@ -425,6 +426,7 @@ def generate_index(root: Path) -> None:
     update_hardcoded_counts(root, stats, skills)
     update_landscape_summary(root)
     update_phase_mapping(root)
+    update_landscape_reviewed(root)
     update_roadmap_metrics(root, stats)
     update_traceability_matrix(root)
     update_doc_inventory(root)

--- a/scripts/playbook_validator/index_updaters.py
+++ b/scripts/playbook_validator/index_updaters.py
@@ -264,6 +264,130 @@ def update_phase_mapping(root: Path) -> None:
     splice_generated_block(root / "docs" / "FEDERAL-AI-LANDSCAPE.md", "LANDSCAPE_PHASES", table)
 
 
+# ── Federal AI landscape freshness stamp (evergreen last-reviewed date) ──
+#
+# The landscape doc's "Last reviewed" date used to be hand-typed in three
+# places (frontmatter last_updated, frontmatter last_reviewed, and an intro
+# prose line) and drifted from the YAML registry's own last_reviewed. This
+# updater makes the YAML registry's `last_reviewed` the single source of truth
+# and propagates it into the doc on `make generate`, so the doc's date can no
+# longer drift. The registry date itself is bumped when the entries change (see
+# bump_landscape_reviewed_if_changed), not on every generate — so the date stays
+# an honest "as of when the data last changed" signal, not a churn timestamp.
+
+_LANDSCAPE_YAML_REL = "data/federal-ai-landscape.yaml"
+_LANDSCAPE_DOC_REL = "docs/FEDERAL-AI-LANDSCAPE.md"
+_ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def read_landscape_reviewed(root: Path) -> str | None:
+    """Return the registry's `last_reviewed` ISO date, or None if absent/invalid."""
+    landscape = root / _LANDSCAPE_YAML_REL
+    if not landscape.is_file():
+        return None
+    import yaml
+
+    data = yaml.safe_load(landscape.read_text(encoding="utf-8")) or {}
+    value = data.get("last_reviewed")
+    if isinstance(value, str) and _ISO_DATE_RE.match(value.strip()):
+        return value.strip()
+    return None
+
+
+def _set_frontmatter_date(text: str, field: str, date: str) -> str:
+    """Replace a single top-level frontmatter `field: "date"` line in-place.
+
+    Only touches a line inside the leading `---` frontmatter block. No-op if the
+    field is absent (we do not invent frontmatter keys here).
+    """
+    if not text.startswith("---"):
+        return text
+    end = text.find("\n---", 3)
+    if end == -1:
+        return text
+    head, rest = text[: end + 1], text[end + 1 :]
+    pattern = re.compile(rf'(?m)^({re.escape(field)}:\s*)"?[^"\n]*"?\s*$')
+    if not pattern.search(head):
+        return text
+    new_head = pattern.sub(rf'\1"{date}"', head, count=1)
+    return new_head + rest
+
+
+def update_landscape_reviewed(root: Path) -> None:
+    """Propagate the registry `last_reviewed` date into the landscape doc.
+
+    Writes the date into the doc's frontmatter `last_updated` and `last_reviewed`
+    and into the `GENERATED:LANDSCAPE_REVIEWED` prose fence. No-op if the registry
+    date is unreadable or the doc is absent; the prose line only updates if the
+    fence markers exist. Prose outside the fence is preserved verbatim.
+    """
+    date = read_landscape_reviewed(root)
+    if date is None:
+        return
+    doc = root / _LANDSCAPE_DOC_REL
+    if not doc.is_file():
+        return
+    text = doc.read_text(encoding="utf-8")
+    updated = _set_frontmatter_date(text, "last_updated", date)
+    updated = _set_frontmatter_date(updated, "last_reviewed", date)
+    if updated != text:
+        doc.write_text(updated, encoding="utf-8")
+    # The visible prose stamp lives inside a generated fence so it cannot drift.
+    body = (
+        f"> **Last reviewed:** {date}. Federal AI policy is evolving rapidly. "
+        "Verify status before citing in compliance documents."
+    )
+    splice_generated_block(doc, "LANDSCAPE_REVIEWED", body)
+
+
+def bump_landscape_reviewed_if_changed(root: Path, today: str, previous_entries_hash: str | None) -> bool:
+    """Advance the registry `last_reviewed` to ``today`` iff the entries changed.
+
+    Intended for the discovery/update path (not `make generate`): the caller
+    supplies a hash of the entries taken BEFORE its edits; if the current entries
+    hash differs, the registry data changed and the review date is bumped. Returns
+    True if the date was advanced. Keeps `last_reviewed` an honest "as of the last
+    data change" signal rather than a per-run timestamp.
+    """
+    landscape = root / _LANDSCAPE_YAML_REL
+    if not landscape.is_file():
+        return False
+    if not _ISO_DATE_RE.match(today):
+        return False
+    text = landscape.read_text(encoding="utf-8")
+    if previous_entries_hash is not None and previous_entries_hash == landscape_entries_hash(root):
+        return False  # entries unchanged — do not bump
+    pattern = re.compile(r'(?m)^(last_reviewed:\s*)"?[^"\n]*"?\s*$')
+    if not pattern.search(text):
+        return False
+    new_text = pattern.sub(rf'\1"{today}"', text, count=1)
+    if new_text != text:
+        landscape.write_text(new_text, encoding="utf-8")
+        return True
+    return False
+
+
+def landscape_entries_hash(root: Path) -> str | None:
+    """Stable hash of the registry entries (order-independent), or None if absent.
+
+    Used to detect real data changes (add/remove/modify) without storing a full
+    prior copy. Excludes the header fields (version, last_reviewed, total_entries)
+    so a date bump alone does not look like a data change.
+    """
+    landscape = root / _LANDSCAPE_YAML_REL
+    if not landscape.is_file():
+        return None
+    import hashlib
+    import json
+
+    import yaml
+
+    data = yaml.safe_load(landscape.read_text(encoding="utf-8")) or {}
+    entries = data.get("entries", [])
+    canonical = json.dumps(entries, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
 # ── Neutral document inventory (#199) ─────────────────────────────────
 #
 # A single generated "all documents" table sourced from INDEX.yaml — the

--- a/scripts/playbook_validator/validate_landscape.py
+++ b/scripts/playbook_validator/validate_landscape.py
@@ -135,6 +135,7 @@ def validate_landscape_doc_summary(root: Path) -> list[str]:
     from playbook_validator.index_updaters import (
         compute_landscape_summary,
         compute_phase_mapping,
+        read_landscape_reviewed,
         render_landscape_summary_table,
         render_phase_mapping_table,
     )
@@ -151,6 +152,46 @@ def validate_landscape_doc_summary(root: Path) -> list[str]:
         expected = render_phase_mapping_table(mapping)
         errors += _check_generated_block(doc, text, "LANDSCAPE_PHASES", expected, "Playbook Phase Mapping table")
 
+    errors += _check_landscape_reviewed(root, doc, text, read_landscape_reviewed(root))
+
+    return errors
+
+
+def _check_landscape_reviewed(root: Path, doc: Path, text: str, date: str | None) -> list[str]:
+    """Fail closed if the doc's freshness date drifts from the registry (evergreen guard).
+
+    Cross-artifact check: the registry's `last_reviewed` is the single source of
+    truth. The doc's frontmatter `last_updated`/`last_reviewed` and the
+    ``GENERATED:LANDSCAPE_REVIEWED`` prose stamp must all equal it. No-op if the
+    registry date is unreadable (that is validate_landscape's own count-contract
+    job, handled elsewhere). Guards a field/marker only when it is present.
+    """
+    if date is None:
+        return []
+    errors: list[str] = []
+
+    # Generated prose stamp (only if the fence exists — mirrors _check_generated_block).
+    start = "<!-- GENERATED:LANDSCAPE_REVIEWED:START"
+    end = "<!-- GENERATED:LANDSCAPE_REVIEWED:END -->"
+    if start in text and end in text:
+        block = text.split(start, 1)[1].split(end, 1)[0]
+        if f"**Last reviewed:** {date}" not in block:
+            errors.append(
+                f"{doc} — 'Last reviewed' stamp is out of sync with "
+                f"data/federal-ai-landscape.yaml last_reviewed ({date}). Run `make generate`."
+            )
+
+    # Frontmatter dates (only fields that are present).
+    if text.startswith("---"):
+        fm_end = text.find("\n---", 3)
+        head = text[: fm_end + 1] if fm_end != -1 else ""
+        for field in ("last_updated", "last_reviewed"):
+            m = re.search(rf'(?m)^{field}:\s*"?([^"\n]+?)"?\s*$', head)
+            if m and m.group(1).strip() != date:
+                errors.append(
+                    f"{doc} — frontmatter {field} ({m.group(1).strip()}) does not match "
+                    f"data/federal-ai-landscape.yaml last_reviewed ({date}). Run `make generate`."
+                )
     return errors
 
 

--- a/scripts/tests/test_generate_index.py
+++ b/scripts/tests/test_generate_index.py
@@ -743,6 +743,98 @@ class TestLandscapeDocGuard:
         assert errors and "out of sync" in errors[0]
 
 
+class TestLandscapeReviewedFreshness:
+    """The evergreen last-reviewed stamp: generated from the registry, drift-guarded."""
+
+    def _write(self, root, registry_date, doc_body):
+        (root / "data").mkdir(exist_ok=True)
+        (root / "data" / "federal-ai-landscape.yaml").write_text(
+            f'version: "1.0"\nlast_reviewed: "{registry_date}"\ntotal_entries: 1\n'
+            "entries:\n  - id: eo-1\n    category: executive_order\n    status: active\n"
+        )
+        (root / "docs").mkdir(exist_ok=True)
+        (root / "docs" / "FEDERAL-AI-LANDSCAPE.md").write_text(doc_body)
+
+    def _doc(self, front_date, stamp_date):
+        return (
+            f'---\ntitle: "L"\nstatus: canonical\ntier: 2\n'
+            f'last_updated: "{front_date}"\nlast_reviewed: "{front_date}"\n---\n\n# L\n\n'
+            "<!-- GENERATED:LANDSCAPE_REVIEWED:START -->\n"
+            f"> **Last reviewed:** {stamp_date}. Verify status before citing.\n"
+            "<!-- GENERATED:LANDSCAPE_REVIEWED:END -->\n"
+        )
+
+    def test_read_landscape_reviewed(self, tmp_path):
+        from playbook_validator.index_updaters import read_landscape_reviewed
+
+        self._write(tmp_path, "2026-08-04", "# L\n")
+        assert read_landscape_reviewed(tmp_path) == "2026-08-04"
+
+    def test_generate_propagates_date_into_doc(self, tmp_path):
+        from playbook_validator.index_updaters import update_landscape_reviewed
+
+        self._write(tmp_path, "2026-08-04", self._doc("2026-06-29", "2026-06-29"))
+        update_landscape_reviewed(tmp_path)
+        text = (tmp_path / "docs" / "FEDERAL-AI-LANDSCAPE.md").read_text()
+        assert 'last_updated: "2026-08-04"' in text
+        assert 'last_reviewed: "2026-08-04"' in text
+        assert "**Last reviewed:** 2026-08-04" in text
+        assert "2026-06-29" not in text  # old date fully replaced
+
+    def test_generate_is_idempotent(self, tmp_path):
+        from playbook_validator.index_updaters import update_landscape_reviewed
+
+        self._write(tmp_path, "2026-08-04", self._doc("2026-06-29", "2026-06-29"))
+        update_landscape_reviewed(tmp_path)
+        once = (tmp_path / "docs" / "FEDERAL-AI-LANDSCAPE.md").read_text()
+        update_landscape_reviewed(tmp_path)
+        twice = (tmp_path / "docs" / "FEDERAL-AI-LANDSCAPE.md").read_text()
+        assert once == twice
+
+    def test_drifted_frontmatter_fails(self, tmp_path):
+        from playbook_validator.validate_landscape import validate_landscape_doc_summary
+
+        self._write(tmp_path, "2026-08-04", self._doc("2020-01-01", "2026-08-04"))
+        errors = validate_landscape_doc_summary(tmp_path)
+        assert errors and any("frontmatter" in e and "2020-01-01" in e for e in errors)
+
+    def test_drifted_stamp_fails(self, tmp_path):
+        from playbook_validator.validate_landscape import validate_landscape_doc_summary
+
+        self._write(tmp_path, "2026-08-04", self._doc("2026-08-04", "2020-01-01"))
+        errors = validate_landscape_doc_summary(tmp_path)
+        assert errors and any("Last reviewed" in e for e in errors)
+
+    def test_in_sync_passes(self, tmp_path):
+        from playbook_validator.validate_landscape import validate_landscape_doc_summary
+
+        self._write(tmp_path, "2026-08-04", self._doc("2026-08-04", "2026-08-04"))
+        assert validate_landscape_doc_summary(tmp_path) == []
+
+    def test_bump_only_when_entries_change(self, tmp_path):
+        from playbook_validator.index_updaters import (
+            bump_landscape_reviewed_if_changed,
+            landscape_entries_hash,
+        )
+
+        self._write(tmp_path, "2026-08-04", "# L\n")
+        # unchanged entries → no bump
+        h = landscape_entries_hash(tmp_path)
+        assert bump_landscape_reviewed_if_changed(tmp_path, "2026-09-01", h) is False
+        assert 'last_reviewed: "2026-08-04"' in (tmp_path / "data" / "federal-ai-landscape.yaml").read_text()
+        # changed entries → bump to today
+        reg = tmp_path / "data" / "federal-ai-landscape.yaml"
+        reg.write_text(
+            reg.read_text().replace(
+                "  - id: eo-1\n    category: executive_order\n    status: active\n",
+                "  - id: eo-1\n    category: executive_order\n    status: active\n"
+                "  - id: eo-2\n    category: executive_order\n    status: active\n",
+            )
+        )
+        assert bump_landscape_reviewed_if_changed(tmp_path, "2026-09-01", h) is True
+        assert 'last_reviewed: "2026-09-01"' in reg.read_text()
+
+
 class TestDocInventory:
     def _write_index(self, root, docs):
         import yaml as _yaml


### PR DESCRIPTION
## Problem

`docs/FEDERAL-AI-LANDSCAPE.md` showed **Last reviewed: 2026-06-29** while `data/federal-ai-landscape.yaml` had moved to **2026-08-04**. The counts/tables already regenerate from the YAML, but the **freshness date** was hand-typed in three places (frontmatter `last_updated`, frontmatter `last_reviewed`, and an intro prose line) and orphaned from every generator — so it silently drifted. There was also a contradictory comment *inside* the YAML (`# Last reviewed: 2026-04-06`).

## Fix (registry = single source of truth; doc generated from it)

- **`update_landscape_reviewed`** (new, wired into `make generate`) writes the registry `last_reviewed` into the doc's frontmatter `last_updated` + `last_reviewed` **and** a new `GENERATED:LANDSCAPE_REVIEWED` prose fence. Reuses the proven `splice_generated_block` pattern — hand-written narrative (the per-entry EO descriptions etc.) outside the fence is preserved verbatim.
- **`_set_frontmatter_date`** edits a frontmatter field only if present, only inside the leading `---` block. **`read_landscape_reviewed`** validates the ISO date.
- **Fail-closed CI guard** `_check_landscape_reviewed` in `validate_landscape.py`: ERROR if the doc's generated stamp or frontmatter dates drift from the registry. Guards a field/marker only when present; no-op if the registry date is unreadable.
- Added **`review_cycle: quarterly`** to the doc so the existing staleness warning actually fires if review lapses.
- Fixed the stale in-YAML comment; documented that `last_reviewed` is canonical.

## Auto-bump (honest, change-triggered — for the discovery path, not `make generate`)

- **`landscape_entries_hash`** — order-independent sha256 over **entries only** (excludes header fields, so a date bump can't be mistaken for a data change → no bump loop).
- **`bump_landscape_reviewed_if_changed`** — advances `last_reviewed` to today **only when the entries actually change**. Unit-tested. **Not yet wired** to a caller (that would make the date a churn timestamp on `make generate`); wiring to the `federal-landscape-update` skill is tracked in **#228**. Until then `make generate` faithfully *propagates* the human-set date, which is correct and safe.

## Design note

`last_reviewed` stays an honest "as of when the data last changed" signal — the doc always reflects it and CI fails if they diverge, rather than the date auto-advancing on every run.

## Validation

- **527 tests pass** (7 new: read, propagate + full date replacement, idempotent, drifted-frontmatter fails, drifted-stamp fails, in-sync passes, bump-only-on-change). Count 520→527 regenerated in README/AGENT-INSTRUCTIONS/ROADMAP.
- `validate-docs`, `validate-landscape`, `generate-check` green. Idempotent (re-generate = no change). Negative-tested (injected drift → guard errors).
- Adversarial nexus review: **7/7 approve**; the one recommendation (don't ship the unwired bump helper as forgotten dead code) is addressed by tracking issue **#228**.

Refs #142

AI-assisted (OpenCode).