### PR TITLE
fix(contract): fail closed when the provisioned contract isn't the universal one

### DIFF
--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -7,10 +7,10 @@
 # before making changes that span multiple documents.
 #
 # Schema version: 1.0
-# Last generated: 2026-08-14
+# Last generated: 2026-08-19
 
 schema_version: "1.0"
-generated: "2026-08-14"
+generated: "2026-08-19"
 repo: "GSA-TTS/agentic-coding-playbook"
 scope: "FIPS Moderate | Single-agent | Internal enterprise"
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Skills convert best practices into step-by-step workflows that any AI coding age
 
 ## Developer Tools
 
-All validation and generation tools live in the `scripts/playbook_validator/` Python package (527 tests).
+All validation and generation tools live in the `scripts/playbook_validator/` Python package (530 tests).
 
 ```bash
 make help              # Show all available commands
@@ -212,7 +212,7 @@ agentic-coding-playbook/
 ├── data/
 │   └── federal-ai-landscape.yaml    # Machine-readable guidance registry
 ├── scripts/
-│   ├── playbook_validator/          # Python validation package (527 tests)
+│   ├── playbook_validator/          # Python validation package (530 tests)
 │   └── tests/                       # TDD test suite
 ├── skills/                          # 12 executable compliance procedures
 ├── templates/                       # PROJECT_PLAN.md, AGENTS.md.template

--- a/docs/AGENT-INSTRUCTIONS.md
+++ b/docs/AGENT-INSTRUCTIONS.md
@@ -16,7 +16,7 @@ Model-agnostic reference for any AI coding agent working in this repository. Rea
 ## Quick Reference
 
 ```bash
-# Validation (Python package — 527 tests)
+# Validation (Python package — 530 tests)
 PYTHONPATH=scripts python3 -m playbook_validator validate-docs
 PYTHONPATH=scripts python3 -m playbook_validator validate-skills
 PYTHONPATH=scripts python3 -m playbook_validator validate-landscape

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,7 +20,7 @@ Long-term plan for making the Agentic Coding Playbook a living, learnable resour
 |--------|-------|
 | Documents | 23 |
 | Skills | 12 |
-| Tests | 527 |
+| Tests | 530 |
 | Checklist items | 62 |
 | Landscape entries | 42 |
 | NIST controls mapped | 35 |

--- a/scripts/playbook_validator/ensure_contract.py
+++ b/scripts/playbook_validator/ensure_contract.py
@@ -62,7 +62,7 @@ STAMP_RELPATH = Path(".agents/cache/AGENTS.universal.stamp")
 
 # Pinned release the cache is fetched from and measured against. The raw URL is
 # hard-coded (never taken from untrusted content) per §11.
-PINNED_RELEASE_TAG = "v0.13.0"
+PINNED_RELEASE_TAG = "v0.14.1"
 CONTRACT_RAW_URL = f"https://raw.githubusercontent.com/GSA-TTS/agentic-coding-playbook/{PINNED_RELEASE_TAG}/AGENTS.md"
 
 _FETCH_TIMEOUT_SECONDS = 15
@@ -217,14 +217,31 @@ def ensure_contract(repo_root: Path, *, allow_fetch: bool = True) -> ContractRes
             message=f"Universal contract is this repository's own {self_contract.name}.",
         )
 
-    # 1. Environment-provided home contract short-circuits everything.
+    # 1. Environment-provided home contract short-circuits everything — but only
+    #    if it is genuinely the universal contract, not merely a non-empty file.
+    #    Existence alone is NOT sufficient: a role-less or project-layer AGENTS.md
+    #    at the home path must fail closed, or the gate passes green on a contract
+    #    that cannot satisfy a downstream `requires_contract`. Validate the
+    #    structured `contract.role: universal` marker, the same signal used to
+    #    recognize the playbook's own contract.
     home_path = _home_contract_path()
     if _is_present(home_path):
+        if _is_playbook_contract(home_path):
+            return ContractResult(
+                status=ContractStatus.HOME,
+                ok=True,
+                path=home_path,
+                message=f"Universal contract present at {home_path}.",
+            )
         return ContractResult(
-            status=ContractStatus.HOME,
-            ok=True,
+            status=ContractStatus.ABSENT,
+            ok=False,
             path=home_path,
-            message=f"Universal contract present at {home_path}.",
+            message=(
+                f"A file exists at {home_path} but it does not declare "
+                "`contract.role: universal` — it is not the universal contract. "
+                "Do NOT proceed; provide the real universal contract at the home path."
+            ),
         )
 
     cache_path = repo_root / CACHE_RELPATH
@@ -237,9 +254,12 @@ def ensure_contract(repo_root: Path, *, allow_fetch: bool = True) -> ContractRes
         "contract at the home path."
     )
 
-    # 2. Fresh cache (present and matching the pinned release tag).
+    # 2. Fresh cache (present, matching the pinned release tag, AND still a
+    #    genuine universal contract). The stamp tag alone is not sufficient — a
+    #    truncated or tampered cache file must fail closed rather than satisfy the
+    #    gate on tag-match alone.
     if _is_present(cache_path):
-        if _read_stamp_tag(stamp_path) == PINNED_RELEASE_TAG:
+        if _read_stamp_tag(stamp_path) == PINNED_RELEASE_TAG and _is_playbook_contract(cache_path):
             return ContractResult(
                 status=ContractStatus.CACHE_FRESH,
                 ok=True,
@@ -247,8 +267,19 @@ def ensure_contract(repo_root: Path, *, allow_fetch: bool = True) -> ContractRes
                 message=f"Universal contract present in cache ({cache_path}).",
                 warning=stale_warning,
             )
-        # Cache exists but is behind the pinned release → try to refresh.
+        # Cache exists but is behind the pinned release (or no longer declares the
+        # universal role) → try to refresh.
         if not allow_fetch:
+            if not _is_playbook_contract(cache_path):
+                return ContractResult(
+                    status=ContractStatus.ABSENT,
+                    ok=False,
+                    path=cache_path,
+                    message=(
+                        f"Cached contract at {cache_path} does not declare "
+                        "`contract.role: universal`; fetch disabled. Do NOT proceed."
+                    ),
+                )
             return ContractResult(
                 status=ContractStatus.STALE,
                 ok=True,

--- a/scripts/tests/test_ensure_contract.py
+++ b/scripts/tests/test_ensure_contract.py
@@ -13,13 +13,23 @@ from playbook_validator.ensure_contract import (
     ensure_contract,
 )
 
-CONTRACT_TEXT = "# AGENTS.md — Federal AI Agent Behavioral Best Practices\n\nrules...\n"
-
 # Frontmatter carrying the structured, versioned contract block. The thin layer
 # legitimately *names* the contract title in prose but declares project-layer.
 UNIVERSAL_FM = (
     '---\ntitle: x\ncontract:\n  role: universal\n  version: "1.0.0"\n---\n'
     "# AGENTS.md — Federal AI Agent Behavioral Best Practices\n"
+)
+
+# The contract file a valid environment provides IS the universal contract, so it
+# must carry the contract.role: universal marker. (Previously this was a bare
+# title string; the gate now validates the marker, not mere existence — #235.)
+CONTRACT_TEXT = UNIVERSAL_FM
+
+# A file that exists and is non-empty but is NOT the universal contract (no
+# contract.role: universal). The gate must fail closed on this, not accept it on
+# mere existence — this is the #235 fail-closed defect.
+NON_UNIVERSAL_FM = (
+    '---\ntitle: x\ncontract:\n  role: project-layer\n  version: "1.0.0"\n---\n# Some project\'s thin AGENTS.md\n'
 )
 
 # Repository root = two levels up from scripts/tests/
@@ -83,6 +93,50 @@ def test_empty_home_file_is_not_present(repo, tmp_path, monkeypatch):
     # Empty home file does not count as present; no cache either → halt.
     assert not result.ok
     assert result.status is ContractStatus.ABSENT
+
+
+# ── #235 fail-closed: a present-but-not-universal contract must NOT pass ──────
+
+
+def test_home_present_but_not_universal_fails_closed(repo, tmp_path, monkeypatch):
+    """The blocker (#235): a non-empty AGENTS.md at the home path that does NOT
+    declare contract.role: universal must fail closed. Existence is not enough —
+    otherwise the gate passes green on a contract that cannot satisfy a
+    downstream requires_contract."""
+    home = tmp_path / "home" / ".agentic-coding-playbook"
+    home.mkdir(parents=True)
+    (home / "AGENTS.md").write_text(NON_UNIVERSAL_FM)
+    monkeypatch.setattr(ec, "DEFAULT_HOME", home)
+
+    result = ensure_contract(repo, allow_fetch=False)
+    assert not result.ok
+    assert result.status is ContractStatus.ABSENT
+
+
+def test_stale_cache_not_universal_no_fetch_fails_closed(repo):
+    """A cached file whose content is not the universal contract must fail closed
+    under --no-fetch, rather than be reported stale-but-ok on tag mismatch."""
+    cache = repo / ec.CACHE_RELPATH
+    stamp = repo / ec.STAMP_RELPATH
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(NON_UNIVERSAL_FM)
+    stamp.write_text("source_url=x\nrelease_tag=v0.0.1-old\nfetched_at=now\n")
+
+    result = ensure_contract(repo, allow_fetch=False)
+    assert not result.ok
+    assert result.status is ContractStatus.ABSENT
+
+
+def test_cli_no_fetch_fails_closed_on_non_universal_home(repo, tmp_path, monkeypatch):
+    """End-to-end via the module CLI path: --no-fetch with a non-universal home
+    file exits non-zero (mirrors the shipped CI workflow's fail-closed step)."""
+    home = tmp_path / "home" / ".agentic-coding-playbook"
+    home.mkdir(parents=True)
+    (home / "AGENTS.md").write_text(NON_UNIVERSAL_FM)
+    monkeypatch.setattr(ec, "DEFAULT_HOME", home)
+
+    result = ensure_contract(repo, allow_fetch=False)
+    assert result.exit_code == 1
 
 
 # ── 2. Fresh cache ──────────────────────────────────────────────────────────

--- a/templates/contract-check.workflow.yaml
+++ b/templates/contract-check.workflow.yaml
@@ -29,12 +29,16 @@ jobs:
 
       # Provide the universal contract to the environment. Replace this step
       # with your organization's standard provisioning (e.g. the
-      # agentic-coding-patterns acq provisioning kit). The probe then verifies offline.
+      # agentic-coding-patterns acq provisioning kit). The probe then verifies
+      # offline that the file is genuinely the universal contract (declares
+      # contract.role: universal) — so the pinned release MUST be one whose
+      # AGENTS.md carries that marker (>= v0.14.0 / contract 1.0.0). Keep this tag
+      # in lockstep with PINNED_RELEASE_TAG in scripts/ensure-contract.py.
       - name: Provision universal behavioral contract
         run: |
           mkdir -p "$HOME/.agentic-coding-playbook"
           curl -fsSL \
-            https://raw.githubusercontent.com/GSA-TTS/agentic-coding-playbook/v0.13.0/AGENTS.md \
+            https://raw.githubusercontent.com/GSA-TTS/agentic-coding-playbook/v0.14.1/AGENTS.md \
             -o "$HOME/.agentic-coding-playbook/AGENTS.md"
 
       - name: Ensure contract is available (fail-closed)

--- a/templates/ensure-contract.py
+++ b/templates/ensure-contract.py
@@ -61,7 +61,7 @@ CONTRACT_ROLE_KEY = "role"
 CONTRACT_ROLE_UNIVERSAL = "universal"
 
 # Pinned release the cache is fetched from and measured against. Hard-coded.
-PINNED_RELEASE_TAG = "v0.13.0"
+PINNED_RELEASE_TAG = "v0.14.1"
 CONTRACT_RAW_URL = f"https://raw.githubusercontent.com/GSA-TTS/agentic-coding-playbook/{PINNED_RELEASE_TAG}/AGENTS.md"
 _FETCH_TIMEOUT_SECONDS = 15
 
@@ -232,10 +232,21 @@ def ensure_contract(repo_root: Path, *, allow_fetch: bool = True) -> int:
         print(f"present-home: universal contract is this repository's own {self_contract.name}")
         return 0
 
+    # A file at the home path satisfies the gate ONLY if it is genuinely the
+    # universal contract (declares contract.role: universal). Existence alone is
+    # not enough — a role-less/project-layer AGENTS.md must fail closed, or the
+    # gate passes green on a contract that cannot satisfy `requires_contract`.
     home_path = _home_contract_path()
     if _is_present(home_path):
-        print(f"present-home: universal contract at {home_path}")
-        return 0
+        if _is_playbook_contract(home_path):
+            print(f"present-home: universal contract at {home_path}")
+            return 0
+        print(
+            f"absent: a file exists at {home_path} but it does not declare "
+            "contract.role: universal — it is not the universal contract. Do NOT proceed.",
+            file=sys.stderr,
+        )
+        return 1
 
     cache_path = repo_root / CACHE_RELPATH
     stamp_path = repo_root / STAMP_RELPATH
@@ -247,11 +258,18 @@ def ensure_contract(repo_root: Path, *, allow_fetch: bool = True) -> int:
     )
 
     if _is_present(cache_path):
-        if _read_stamp_tag(stamp_path) == PINNED_RELEASE_TAG:
+        if _read_stamp_tag(stamp_path) == PINNED_RELEASE_TAG and _is_playbook_contract(cache_path):
             print(warn, file=sys.stderr)
             print(f"present-cache-fresh: universal contract in cache ({cache_path})")
             return 0
         if not allow_fetch:
+            if not _is_playbook_contract(cache_path):
+                print(
+                    f"absent: cached contract at {cache_path} does not declare "
+                    "contract.role: universal; fetch disabled. Do NOT proceed.",
+                    file=sys.stderr,
+                )
+                return 1
             print(warn, file=sys.stderr)
             print(f"present-cache-stale: cached contract not {PINNED_RELEASE_TAG}; fetch disabled")
             return 0


### PR DESCRIPTION
Fixes the `sev:blocker` audit finding GSA-TTS/agentic-coding-playbook#235.

## The defect

The fail-closed contract gate reported **PASS** on a contract that cannot satisfy a downstream `requires_contract`:

1. The probe was pinned to **v0.13.0**, whose `AGENTS.md` has **no `contract:` block** (the marker first appears at v0.14.0). The probe's own fetch path rejects a role-less contract (`ensure_contract.py` `_text_declares_universal`) → `ABSENT` → "do not proceed".
2. But the shipped CI workflow (`templates/contract-check.workflow.yaml`) `curl`s v0.13.0's `AGENTS.md` into `$HOME` and runs `ensure-contract.py --no-fetch`, whose home/cache branches checked **file existence only** — so the step **"Ensure contract is available (fail-closed)"** passed green on a contract with no role/version that fails the thin template's `requires_contract: ">=1.0"`.

Net: the fail-closed guarantee didn't hold.

## The fix (module + shipped template + workflow, in lockstep)

- **Bump the pin** `v0.13.0` → **`v0.14.1`** (its `AGENTS.md` carries `contract.role: universal` / `version: 1.0.0`), and update the workflow `curl` pin to match, with a comment tying the two together.
- **Home path** now accepts a file only if it declares `contract.role: universal` (`_is_playbook_contract`); a present-but-not-universal file returns `ABSENT` (fail closed) instead of `HOME`.
- **Fresh/stale cache** now requires the universal-role marker in addition to the stamp tag; a `--no-fetch` cache that isn't the universal contract fails closed (no more "stale-but-ok" on a wrong file).

## Verification

- **530 tests pass** (3 new fail-closed cases: non-universal home, non-universal stale cache under `--no-fetch`, CLI exit=1). Updated the fixture contract text to carry the universal marker, since existence alone is no longer sufficient by design.
- End-to-end: the shipped template probe now exits **1** on a non-universal home file and **0** on a valid universal one (verified both).
- `ruff` clean; pre-commit (incl. the repo's own contract gate) green. Regenerated the test count (527→530) across README/AGENT-INSTRUCTIONS/ROADMAP/INDEX via `make generate`.

Refs GSA-TTS/agentic-coding-playbook#235

AI-assisted (OpenCode).