### PR TITLE
docs: de-drift stale version/count stamps + restore orphaned §14.2 heading

### DIFF
--- a/.agents/skills/ato-package/SKILL.md
+++ b/.agents/skills/ato-package/SKILL.md
@@ -66,7 +66,7 @@ For `docs/risk-assessment.md`, also verify:
 - Sign-off section has names and dates
 
 For `checklists/pre-deployment.md`, also verify:
-- All 60 items have a Pass/Fail/N/A status
+- All checklist items have a Pass/Fail/N/A status
 - Failed items have remediation notes
 - Sign-off block at the bottom is completed
 

--- a/.agents/skills/federal-pre-deployment-check/SKILL.md
+++ b/.agents/skills/federal-pre-deployment-check/SKILL.md
@@ -27,7 +27,7 @@ human-verified items to produce a completed checklist report.
 ## Check Classification
 
 See [references/CHECK_AUTOMATION.md](references/CHECK_AUTOMATION.md) for the full
-classification of all 60 items. Summary:
+classification of every checklist item. Summary:
 
 | Type | Count | How It Works |
 |------|-------|-------------|
@@ -134,7 +134,7 @@ python3 skills/federal-pre-deployment-check/scripts/generate-checklist-report.py
 ```
 
 Or, construct the completed checklist inline by filling in the Pass/Fail/N/A
-status and notes for each of the 60 items in the checklist format from
+status and notes for each item in the checklist format from
 `checklists/pre-deployment.md`.
 
 ### Step 6: Present Results
@@ -168,5 +168,5 @@ with references to the relevant policy documents (use the
 - The reviewer MUST NOT be the same person who directed the agent (per checklist instructions).
 - Automated checks are best-effort — tool availability varies by environment.
 - The automated checks (`make pre-deploy`) are read-only. They do not modify files, install packages, or make network calls.
-- All 60 items trace back to NIST SP 800-53 controls via the playbook's traceability matrix (docs/TRACEABILITY.md in the agentic-coding-playbook repo) Table 3.
+- All checklist items trace back to NIST SP 800-53 controls via the playbook's traceability matrix (docs/TRACEABILITY.md in the agentic-coding-playbook repo) Table 3.
 - **Policy reference:** `checklists/pre-deployment.md` for the full checklist; the playbook traceability matrix (docs/TRACEABILITY.md in the agentic-coding-playbook repo) for control mappings.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ tier: 1
 contract:
   role: universal
   version: "1.0.0"
-last_updated: "2026-07-22"
+last_updated: "2026-08-19"
 nist_controls: ["AC-2", "AC-3", "AC-6", "AU-2", "AU-3", "AU-12", "CM-2", "CM-3", "CM-5", "CM-6", "CM-7", "CM-10", "IA-8", "IR-4", "IR-6", "PL-4", "SA-4", "SA-5", "SA-8", "SA-11", "SA-15", "SA-17", "SC-7", "SC-8", "SC-13", "SI-10", "SI-17", "SR-3"]
 frameworks: ["NIST SP 800-53 Rev 5.2", "NIST AI RMF 1.0", "NIST AI 600-1", "NCCoE Agent Identity", "OWASP Top 10 LLM 2025", "OWASP Top 10 Agentic 2026"]
 audience: "all"
@@ -573,6 +573,8 @@ The plan-before-execute discipline MUST scale with risk, not be applied uniforml
 
 > Rationale: a heavyweight gate applied to every keystroke loses credibility and gets ignored where it matters. Proportionality keeps the mandatory plan meaningful for the changes that carry real risk.
 
+### 14.2 Pull Request Requirements
+
 The agent MUST ensure all changes are submitted via pull requests that include:
 
 1. **Context** — What problem is being solved and why
@@ -729,6 +731,7 @@ Each section above includes inline control mappings (e.g., `> **Control Mapping:
 
 | Date | Version | Change |
 |------|---------|--------|
+| 2026-08-19 | 1.0.0 | Editorial: restore the missing `### 14.2 Pull Request Requirements` heading so the mandatory PR-requirements block is no longer orphaned inside §14.1.1 (#236); sync `last_updated` to the newest Version History entry (#240). No behavioral rule changed. |
 | 2026-08-07 | 1.0.0 | Reconcile the contract version: the `contract.version` marker, the document banner, `config.CURRENT_CONTRACT_VERSION`, and the thin template's `requires_contract: ">=1.0"` are now all **1.0.0** (was frontmatter 0.4.0 / banner 0.3.0 / config 1.0.0 — a contradiction where 0.4.0 failed the template's `>=1.0`). No behavioral rule changed; this is a version-truth fix (#191) so downstream `requires_contract` compatibility (#153) is well-defined. |
 | 2026-07-22 | 0.4.0 | Add license-acceptance rules: §3.2 requires human approval before accepting a license/EULA on the org's behalf; §5.2 forbids auto-accepting license terms and prefers license-unencumbered equivalents (e.g. CINC over Chef InSpec); add SA-4, CM-10 mappings |
 | 2026-07-06 | 0.3.0 | Split into universal contract + thin project layer; add fail-closed contract-prerequisite probe; designate canonical via a versioned `contract:` frontmatter block (`role: universal`, `version: 1.0.0`) recognized by structure, not content |

--- a/CONTEXT-GUIDE.md
+++ b/CONTEXT-GUIDE.md
@@ -23,13 +23,13 @@ review_cycle: "quarterly"
 3. **Load on demand** — do NOT load all documents preemptively
 4. **Security is non-negotiable** — when in doubt about a security requirement, load the relevant doc rather than guessing
 
-## Tier 1 — Always Load (~15,503 words)
+## Tier 1 — Always Load (~15,549 words)
 
 These define the behavioral contract. Load for **every task**.
 
 | Document | Words | What It Covers |
 |----------|-------|----------------|
-| `AGENTS.md` | 5,744 | Agent rules: permissions, prohibitions, data handling, identity, meta-constraints |
+| `AGENTS.md` | 5,790 | Agent rules: permissions, prohibitions, data handling, identity, meta-constraints |
 | `PLAYBOOK.md` | 1,202 | Step-by-step guide: project setup → deployment (9 phases, 12 skills) |
 | `docs/CODING_PRACTICES.md` | 6,886 | Secure coding: input validation, secrets, dependencies, architecture, TDD, SOLID |
 | `docs/CODING_STANDARDS_COMPACT.md` | 450 | **Code generation shortcut** — load INSTEAD of full CODING_PRACTICES.md for routine code tasks |

--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -38,7 +38,7 @@ documents:
     status: canonical
     tier: 1
     load_priority: always
-    last_updated: "2026-07-22"
+    last_updated: "2026-08-19"
     audience: all
     nist_controls_count: 28
     review_cycle: quarterly

--- a/checklists/pre-deployment.md
+++ b/checklists/pre-deployment.md
@@ -25,7 +25,7 @@ review_cycle: "semi-annually"
   4. Retain completed checklists as part of your deployment records
   5. The reviewer completing this checklist MUST NOT be the same person who directed the agent
 
-  Based on: Agentic Coding Playbook v0.4.0
+  Based on: the Agentic Coding Playbook
   Aligned with: NIST SP 800-53 Rev 5.2, OWASP Top 10 for LLM/Agentic Applications
 -->
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,7 +13,7 @@ keywords: ["roadmap", "plan", "future", "strategy"]
 
 Long-term plan for making the Agentic Coding Playbook a living, learnable resource for federal engineers.
 
-## Current State (v0.6.0)
+## Current State
 
 <!-- GENERATED:ROADMAP_METRICS:START — do not edit, run: make generate -->
 | Metric | Count |

--- a/templates/privacy-impact-assessment.md
+++ b/templates/privacy-impact-assessment.md
@@ -24,7 +24,7 @@ review_cycle: "annually"
   3. Update when AI components, data flows, or system purpose change materially
   4. Retain completed PIAs as part of your ATO documentation package
 
-  Based on: Agentic Coding Playbook v0.4.0
+  Based on: the Agentic Coding Playbook
   Aligned with: Privacy Act of 1974, E-Government Act of 2002 (Section 208), OMB Circular A-130
 -->
 

--- a/templates/risk-assessment.md
+++ b/templates/risk-assessment.md
@@ -24,7 +24,7 @@ review_cycle: "semi-annually"
   3. Update when the agent, system, or environment changes materially
   4. Retain completed assessments as part of your ATO documentation
 
-  Based on: Agentic Coding Playbook v0.4.0
+  Based on: the Agentic Coding Playbook
   Aligned with: NIST AI RMF 1.0 (GOVERN, MAP, MEASURE, MANAGE)
   NIST SP 800-53: RA-3 (Risk Assessment)
 -->


### PR DESCRIPTION
Doc-accuracy batch from the Fable audit (epic #234) plus two editorial AGENTS.md fixes. **No behavioral rule changed.** 3/3 consensus (architect/security/scope-steward) on scope + safety.

## #253 — stale playbook version stamps (8 releases behind)
Made the phrasing **version-neutral** rather than stamping the release number (which bumps every release and adds no reader value; the repo already decoupled the *contract* version for the same reason):
- `checklists/pre-deployment.md`, `templates/risk-assessment.md`, `templates/privacy-impact-assessment.md` — `Based on: Agentic Coding Playbook v0.4.0` → `Based on: the Agentic Coding Playbook` (inside provenance HTML-comment blocks).
- `docs/ROADMAP.md` — `## Current State (v0.6.0)` → `## Current State` (the generated metrics table directly below is the real source-derived current state).

## #252 (prose portion only) — "60 items" vs the checklist's actual 62
Four stale "60 items" claims → version-neutral "every/all checklist item(s)" in `ato-package` + `federal-pre-deployment-check` SKILL.md. The checklist's authoritative Summary row already says **62**.
> **Deferred to a dedicated generator-wiring PR** (needs its own review): the report script (`generate-checklist-report.py`) hardcodes only **58** items and **10** categories — it is *missing* items 9.7/9.8/11.1/11.2 and the "Accessibility" category, so it would silently score 4 real items as unknown. That's a logic fix + single-source parse, not a prose edit.

## #236 — orphaned mandatory block (structural)
Restored the missing `### 14.2 Pull Request Requirements` heading. The mandatory PR-requirements MUST-block was physically nested under §14.1.1 (Expedited Mode), so a top-level obligation read as expedited-mode-scoped. Numbering/structure only; no rule wording touched.

## #240 — stale timestamp
`last_updated` 2026-07-22 → 2026-08-19 to match the newest Version History entry (the 2026-08-07 contract-version fix bumped the history but not the stamp); added a Version History row for #236/#240.

## Generated side effects
`make generate` regenerated CONTEXT-GUIDE word counts + INDEX.yaml date from the AGENTS.md word-count change.

## Verification
`make validate` green · `generate-index --check` up-to-date · 527 tests pass · pre-commit (gitleaks + ensure-contract) green.

## Deliberately EXCLUDED (each gets its own review)
#238 (nist_controls frontmatter — feeds the generated traceability matrix), #242 (identity rule, normative), #244 (co-author email, cross-repo), #245 (contract-layering, ADR-worthy), #252 report-script generator wiring, #254 PLAYBOOK skill-table generation, #255 test-count guard, #256 context-guide regex.

Refs #234 #252 #253 #236 #240

AI-assisted (OpenCode).