### PR TITLE
fix(validators): enforce frontmatter enums, single-source exclusions, close staleness gap (#243/#247/#248/#249)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ tier: 1
 contract:
   role: universal
   version: "1.0.0"
-last_updated: "2026-08-19"
+last_updated: "2026-08-20"
 nist_controls: ["AC-2", "AC-3", "AC-6", "AU-2", "AU-3", "AU-12", "CM-2", "CM-3", "CM-5", "CM-6", "CM-7", "CM-10", "IA-8", "IR-4", "IR-6", "PL-4", "SA-4", "SA-5", "SA-8", "SA-11", "SA-15", "SA-17", "SC-7", "SC-8", "SC-13", "SI-10", "SI-17", "SR-3"]
 frameworks: ["NIST SP 800-53 Rev 5.2", "NIST AI RMF 1.0", "NIST AI 600-1", "NCCoE Agent Identity", "OWASP Top 10 LLM 2025", "OWASP Top 10 Agentic 2026"]
 audience: "all"
@@ -531,11 +531,21 @@ The agent SHOULD:
 
 ### 13.2 Frontmatter Requirements
 
-All `.md` content files in this repository MUST include YAML frontmatter with at minimum:
+All `.md` **content** files in this repository MUST include YAML frontmatter with at minimum:
 - `title` — Document title
 - `description` — One-line summary
 - `status` — `canonical`, `draft`, or `deprecated`
 - `tier` — `1` (core standards), `2` (supporting), or `3` (templates/checklists)
+
+Repository **meta-files** are exempt (they legitimately carry no frontmatter):
+`README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, `SECURITY.md`,
+`CODE_OF_CONDUCT.md`, `SUPPORT.md`, `GOVERNANCE.md`, `ACCESSIBILITY.md`,
+`TRANSFER.md`, and `LICENSE`. This exemption list is the single source of truth
+in `scripts/playbook_validator/config.py` (`STRUCTURAL_EXCLUDED_FILENAMES`),
+which both the frontmatter validator and the index generator consume, so the
+rule and the tooling can never diverge. The `skills/` (canonical `.agents/`) and
+`data/`/`decisions/` trees are validated by their own validators, not by the
+document-frontmatter check.
 
 When updating a document, the agent SHOULD update `last_updated` in the frontmatter.
 
@@ -731,6 +741,7 @@ Each section above includes inline control mappings (e.g., `> **Control Mapping:
 
 | Date | Version | Change |
 |------|---------|--------|
+| 2026-08-20 | 1.0.0 | Editorial: §13.2 now states the frontmatter-exemption explicitly (lists the exempt repository meta-files and points at the `config.py` single source), reconciling the prose with the tool so the rule and the validator can no longer diverge (#247). No behavioral rule changed. |
 | 2026-08-19 | 1.0.0 | Editorial: restore the missing `### 14.2 Pull Request Requirements` heading so the mandatory PR-requirements block is no longer orphaned inside §14.1.1 (#236); sync `last_updated` to the newest Version History entry (#240). No behavioral rule changed. |
 | 2026-08-07 | 1.0.0 | Reconcile the contract version: the `contract.version` marker, the document banner, `config.CURRENT_CONTRACT_VERSION`, and the thin template's `requires_contract: ">=1.0"` are now all **1.0.0** (was frontmatter 0.4.0 / banner 0.3.0 / config 1.0.0 — a contradiction where 0.4.0 failed the template's `>=1.0`). No behavioral rule changed; this is a version-truth fix (#191) so downstream `requires_contract` compatibility (#153) is well-defined. |
 | 2026-07-22 | 0.4.0 | Add license-acceptance rules: §3.2 requires human approval before accepting a license/EULA on the org's behalf; §5.2 forbids auto-accepting license terms and prefers license-unencumbered equivalents (e.g. CINC over Chef InSpec); add SA-4, CM-10 mappings |

--- a/CONTEXT-GUIDE.md
+++ b/CONTEXT-GUIDE.md
@@ -23,17 +23,17 @@ review_cycle: "quarterly"
 3. **Load on demand** — do NOT load all documents preemptively
 4. **Security is non-negotiable** — when in doubt about a security requirement, load the relevant doc rather than guessing
 
-## Tier 1 — Always Load (~15,549 words)
+## Tier 1 — Always Load (~15,668 words)
 
 These define the behavioral contract. Load for **every task**.
 
 | Document | Words | What It Covers |
 |----------|-------|----------------|
-| `AGENTS.md` | 5,790 | Agent rules: permissions, prohibitions, data handling, identity, meta-constraints |
+| `AGENTS.md` | 5,905 | Agent rules: permissions, prohibitions, data handling, identity, meta-constraints |
 | `PLAYBOOK.md` | 1,202 | Step-by-step guide: project setup → deployment (9 phases, 12 skills) |
 | `docs/CODING_PRACTICES.md` | 6,886 | Secure coding: input validation, secrets, dependencies, architecture, TDD, SOLID |
-| `docs/CODING_STANDARDS_COMPACT.md` | 450 | **Code generation shortcut** — load INSTEAD of full CODING_PRACTICES.md for routine code tasks |
-| `docs/AGENT-INSTRUCTIONS.md` | 1,221 | Repo-specific tooling reference: canonical paths, validation commands, context budgets |
+| `docs/CODING_STANDARDS_COMPACT.md` | 452 | **Code generation shortcut** — load INSTEAD of full CODING_PRACTICES.md for routine code tasks |
+| `docs/AGENT-INSTRUCTIONS.md` | 1,223 | Repo-specific tooling reference: canonical paths, validation commands, context budgets |
 
 ## Tier 2 — Load When Task Matches (~12,840 words)
 

--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -25,7 +25,7 @@ frontmatter_schema:
     1: "Core — behavioral best practices, rules, and control mappings"
     2: "Supporting documentation — how-to guides and setup instructions"
     3: "Templates and checklists — reusable artifacts for projects"
-  audience_values: ["all", "developers", "isso", "managers"]
+  audience_values: ["agents", "all", "developers", "isso", "managers"]
   load_priority_values: ["always", "on-demand", "reference-only", "task-context"]
   review_cycle_values: ["annually", "quarterly", "semi-annually"]
 
@@ -38,7 +38,7 @@ documents:
     status: canonical
     tier: 1
     load_priority: always
-    last_updated: "2026-08-19"
+    last_updated: "2026-08-20"
     audience: all
     nist_controls_count: 28
     review_cycle: quarterly
@@ -58,7 +58,7 @@ documents:
     status: canonical
     tier: 1
     load_priority: always
-    audience: [developers, tech-leads, agents]
+    audience: [developers, managers, agents]
 
   - path: "docs/AGENT-IDENTITY.md"
     title: "Agent Identity, Authentication, Authorization, and Delegation"
@@ -79,6 +79,7 @@ documents:
     load_priority: always
     last_updated: "2026-06-01"
     audience: [developers, agents]
+    review_cycle: quarterly
 
   - path: "docs/CODING_PRACTICES.md"
     title: "Secure Coding Practices for AI-Assisted Federal Development"
@@ -99,6 +100,7 @@ documents:
     load_priority: task-context
     last_updated: "2026-06-01"
     audience: [agents]
+    review_cycle: quarterly
 
   - path: "docs/SECURITY-CONTROLS.md"
     title: "NIST SP 800-53 Rev 5.2 Control Overlay for Agentic AI Systems"
@@ -203,6 +205,7 @@ documents:
     last_updated: "2026-06-01"
     audience: [developers, agents]
     nist_controls_count: 2
+    review_cycle: quarterly
 
   - path: "docs/ROADMAP.md"
     title: "Roadmap"
@@ -212,6 +215,7 @@ documents:
     load_priority: reference-only
     last_updated: "2026-06-01"
     audience: [developers, managers]
+    review_cycle: quarterly
 
   - path: "examples/AGENTS.md.example"
     title: "Example: AGENTS.md for a Federal Web Application"
@@ -239,7 +243,7 @@ documents:
     status: canonical
     tier: 3
     load_priority: reference-only
-    audience: [developers, tech-leads, managers]
+    audience: [developers, managers]
 
   - path: "templates/privacy-impact-assessment.md"
     title: "Privacy Impact Assessment for AI-Enabled Systems"

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -3,7 +3,7 @@ title: "Federal AI Coding Playbook"
 description: "Step-by-step guide for starting a federal coding project with AI agents"
 tier: 1
 load_priority: always
-audience: ["developers", "tech-leads", "agents"]
+audience: ["developers", "managers", "agents"]
 status: canonical
 related:
   - AGENTS.md

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Skills convert best practices into step-by-step workflows that any AI coding age
 
 ## Developer Tools
 
-All validation and generation tools live in the `scripts/playbook_validator/` Python package (536 tests).
+All validation and generation tools live in the `scripts/playbook_validator/` Python package (542 tests).
 
 ```bash
 make help              # Show all available commands
@@ -212,7 +212,7 @@ agentic-coding-playbook/
 ├── data/
 │   └── federal-ai-landscape.yaml    # Machine-readable guidance registry
 ├── scripts/
-│   ├── playbook_validator/          # Python validation package (536 tests)
+│   ├── playbook_validator/          # Python validation package (542 tests)
 │   └── tests/                       # TDD test suite
 ├── skills/                          # 12 executable compliance procedures
 ├── templates/                       # PROJECT_PLAN.md, AGENTS.md.template

--- a/docs/AGENT-INSTRUCTIONS.md
+++ b/docs/AGENT-INSTRUCTIONS.md
@@ -4,6 +4,7 @@ description: "Model-agnostic repo-specific reference for any AI coding agent wor
 status: canonical
 tier: 1
 last_updated: "2026-06-01"
+review_cycle: "quarterly"
 load_priority: always
 audience: ["developers", "agents"]
 keywords: ["agent", "instructions", "commands", "paths", "skills", "validation"]
@@ -16,7 +17,7 @@ Model-agnostic reference for any AI coding agent working in this repository. Rea
 ## Quick Reference
 
 ```bash
-# Validation (Python package — 536 tests)
+# Validation (Python package — 542 tests)
 PYTHONPATH=scripts python3 -m playbook_validator validate-docs
 PYTHONPATH=scripts python3 -m playbook_validator validate-skills
 PYTHONPATH=scripts python3 -m playbook_validator validate-landscape

--- a/docs/CODING_STANDARDS_COMPACT.md
+++ b/docs/CODING_STANDARDS_COMPACT.md
@@ -4,6 +4,7 @@ description: "LLM-optimized coding standards for inclusion in code generation co
 status: canonical
 tier: 1
 last_updated: "2026-06-01"
+review_cycle: "quarterly"
 load_priority: task-context
 audience: ["agents"]
 keywords: ["coding", "code generation", "standards", "compact", "prompt"]

--- a/docs/PROMPT-INJECTION-DEFENSE.md
+++ b/docs/PROMPT-INJECTION-DEFENSE.md
@@ -4,6 +4,7 @@ description: "Implementation patterns for defending against prompt injection in 
 status: canonical
 tier: 3
 last_updated: "2026-06-01"
+review_cycle: "quarterly"
 load_priority: on-demand
 audience: ["developers", "agents"]
 keywords: ["prompt injection", "defense", "security", "input validation", "output filtering"]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,6 +4,7 @@ description: "Long-term plan for the Agentic Coding Playbook — making it a liv
 status: canonical
 tier: 3
 last_updated: "2026-06-01"
+review_cycle: "quarterly"
 load_priority: reference-only
 audience: ["developers", "managers"]
 keywords: ["roadmap", "plan", "future", "strategy"]
@@ -20,7 +21,7 @@ Long-term plan for making the Agentic Coding Playbook a living, learnable resour
 |--------|-------|
 | Documents | 23 |
 | Skills | 12 |
-| Tests | 536 |
+| Tests | 542 |
 | Checklist items | 62 |
 | Landscape entries | 42 |
 | NIST controls mapped | 35 |

--- a/scripts/playbook_validator/config.py
+++ b/scripts/playbook_validator/config.py
@@ -26,9 +26,51 @@ OPTIONAL_FRONTMATTER_FIELDS = frozenset(
 
 DOC_STATUS_VALUES = frozenset({"canonical", "draft", "deprecated"})
 DOC_TIER_VALUES = frozenset({1, 2, 3})
-DOC_AUDIENCE_VALUES = frozenset({"developers", "isso", "managers", "all"})
+DOC_AUDIENCE_VALUES = frozenset({"developers", "isso", "managers", "agents", "all"})
 DOC_LOAD_PRIORITY_VALUES = frozenset({"always", "task-context", "on-demand", "reference-only"})
 DOC_REVIEW_CYCLE_VALUES = frozenset({"quarterly", "semi-annually", "annually"})
+
+# ── Structural (non-content) files & dirs excluded from doc scanning ──
+#
+# SINGLE SOURCE OF TRUTH (#248). Both the frontmatter validator
+# (validate_docs) and the index generator (generate_index) exclude these, and
+# they MUST agree — otherwise a file can be indexed by one and never validated
+# by the other (a real gap: a tier-3 template shipped an invalid enum value that
+# was indexed into INDEX.yaml but structurally unreachable by validation).
+#
+# Repository meta-files: standard OSS/community health files that legitimately
+# carry no frontmatter. The AGENTS.md §13.2 exemption prose is reconciled to
+# THIS list (#247) — keep the two in lockstep.
+STRUCTURAL_EXCLUDED_FILENAMES = frozenset(
+    {
+        "README.md",
+        "CONTRIBUTING.md",
+        "CHANGELOG.md",
+        "SECURITY.md",
+        "CODE_OF_CONDUCT.md",
+        "SUPPORT.md",
+        "GOVERNANCE.md",
+        "ACCESSIBILITY.md",
+        "LICENSE",
+        "TRANSFER.md",
+    }
+)
+
+# Directories excluded from *content* discovery. `.agents` holds the canonical
+# skills tree (validated by validate-skills, not validate-docs); the rest are
+# VCS/CI/build/data dirs with no frontmatter-bearing content docs.
+STRUCTURAL_EXCLUDED_DIRS = frozenset(
+    {
+        ".git",
+        ".github",
+        ".claude",
+        ".agents",
+        "node_modules",
+        "skills",
+        "data",
+        "decisions",
+    }
+)
 
 # ── Behavioral-Contract Designation (canonical, versioned) ───────────
 #

--- a/scripts/playbook_validator/generate_index.py
+++ b/scripts/playbook_validator/generate_index.py
@@ -23,12 +23,16 @@ from playbook_validator.config import (
     DOC_STATUS_VALUES,
     OPTIONAL_FRONTMATTER_FIELDS,
     REQUIRED_FRONTMATTER_FIELDS,
+    STRUCTURAL_EXCLUDED_DIRS,
+    STRUCTURAL_EXCLUDED_FILENAMES,
 )
 from playbook_validator.frontmatter import extract_frontmatter
 
-# Files and directories excluded from content scanning (matches generate-index.sh)
-_EXCLUDED_DIRS = {".git", ".github", "node_modules", "skills"}
-_EXCLUDED_NAMES = {"CONTRIBUTING.md", "CHANGELOG.md", "README.md", "SECURITY.md", "LICENSE"}
+# Files and directories excluded from content scanning. Single-sourced in
+# config.py (#248) so the index generator and the frontmatter validator can
+# never disagree on the corpus.
+_EXCLUDED_DIRS = set(STRUCTURAL_EXCLUDED_DIRS)
+_EXCLUDED_NAMES = set(STRUCTURAL_EXCLUDED_FILENAMES)
 
 # Tier descriptions used in the YAML header
 _TIER_DESCRIPTIONS = {

--- a/scripts/playbook_validator/validate_docs.py
+++ b/scripts/playbook_validator/validate_docs.py
@@ -14,45 +14,26 @@ from playbook_validator.config import (
     CONTRACT_ROLE_UNIVERSAL,
     CONTRACT_ROLE_VALUES,
     CONTRACT_VERSION_KEY,
+    DOC_AUDIENCE_VALUES,
     DOC_LOAD_PRIORITY_VALUES,
+    DOC_REVIEW_CYCLE_VALUES,
     DOC_STATUS_VALUES,
     DOC_TIER_VALUES,
     REQUIRED_FRONTMATTER_FIELDS,
+    STRUCTURAL_EXCLUDED_DIRS,
+    STRUCTURAL_EXCLUDED_FILENAMES,
     contract_block,
     contract_role,
     contract_version,
 )
 from playbook_validator.frontmatter import extract_frontmatter
 
-# Files excluded from frontmatter validation
-EXCLUDED_FILENAMES = frozenset(
-    {
-        "README.md",
-        "CONTRIBUTING.md",
-        "CHANGELOG.md",
-        "SECURITY.md",
-        "CODE_OF_CONDUCT.md",
-        "SUPPORT.md",
-        "GOVERNANCE.md",
-        "ACCESSIBILITY.md",
-        "LICENSE",
-        "TRANSFER.md",
-    }
-)
-
-# Directories excluded from content file discovery
-EXCLUDED_DIRS = frozenset(
-    {
-        ".git",
-        ".github",
-        ".claude",
-        "node_modules",
-        "skills",
-        "data",
-        "templates",
-        "decisions",
-    }
-)
+# Structural (non-content) files & dirs excluded from frontmatter validation.
+# Single-sourced in config.py (#248) so validate_docs and generate_index can
+# never diverge on what "the corpus" is. The §13.2 exemption prose tracks
+# STRUCTURAL_EXCLUDED_FILENAMES (#247).
+EXCLUDED_FILENAMES = STRUCTURAL_EXCLUDED_FILENAMES
+EXCLUDED_DIRS = STRUCTURAL_EXCLUDED_DIRS
 
 
 def find_content_files(root: Path) -> list[Path]:
@@ -107,6 +88,21 @@ def validate_doc_frontmatter(path: Path) -> tuple[list[str], list[str]]:
     if load_priority is not None and load_priority not in DOC_LOAD_PRIORITY_VALUES:
         errors.append(
             f"{path} — invalid load_priority: '{load_priority}' (must be one of {sorted(DOC_LOAD_PRIORITY_VALUES)})"
+        )
+
+    # Audience validation (optional; scalar or list of enum values) (#243)
+    audience = fm.get("audience")
+    if audience is not None:
+        values = audience if isinstance(audience, list) else [audience]
+        for a in values:
+            if a not in DOC_AUDIENCE_VALUES:
+                errors.append(f"{path} — invalid audience: '{a}' (must be one of {sorted(DOC_AUDIENCE_VALUES)})")
+
+    # Review-cycle validation (optional field) (#243)
+    review_cycle = fm.get("review_cycle")
+    if review_cycle is not None and review_cycle not in DOC_REVIEW_CYCLE_VALUES:
+        errors.append(
+            f"{path} — invalid review_cycle: '{review_cycle}' (must be one of {sorted(DOC_REVIEW_CYCLE_VALUES)})"
         )
 
     # Behavioral-contract block validation (optional). When present it must be a
@@ -200,6 +196,16 @@ def _validate_freshness(path: Path, fm: dict, errors: list[str], warnings: list[
                 f"old, exceeding the {cycle} review cycle ({_REVIEW_CYCLE_DAYS[cycle]} days). "
                 "Review and bump last_updated, or set stale_after (#210)."
             )
+    elif updated is not None and cycle not in _REVIEW_CYCLE_DAYS:
+        # #249: a doc carries last_updated but no review_cycle / stale_after, so
+        # staleness can never be derived — the doc is silently exempt from the
+        # freshness rule. Surface the coverage gap (warning) rather than let it
+        # sit undetectable.
+        warnings.append(
+            f"{path} — carries last_updated but no review_cycle or stale_after, "
+            "so staleness cannot be derived (this doc is exempt from the freshness "
+            "rule). Add a review_cycle or an explicit stale_after (#249)."
+        )
 
 
 # Control-overlay body rows look like: | **AC-2** | Account Management | ...

--- a/scripts/tests/test_generate_index.py
+++ b/scripts/tests/test_generate_index.py
@@ -1193,3 +1193,31 @@ class TestFrameworkRefs:
         root = Path(__file__).resolve().parents[2]
         assert _validate_framework_refs(root) == []
         assert _validate_framework_frontmatter(root) == []
+
+
+class TestExclusionListsSingleSource:
+    """#248: validate_docs and generate_index MUST share one exclusion source."""
+
+    def test_structural_lists_are_single_sourced(self):
+        from playbook_validator import config, generate_index, validate_docs
+
+        # Set-equality against the config single source, so a file can never be
+        # indexed by one tool and left unvalidated by the other.
+        assert validate_docs.EXCLUDED_FILENAMES == config.STRUCTURAL_EXCLUDED_FILENAMES
+        assert validate_docs.EXCLUDED_DIRS == config.STRUCTURAL_EXCLUDED_DIRS
+        assert set(config.STRUCTURAL_EXCLUDED_FILENAMES) == generate_index._EXCLUDED_NAMES
+        assert set(config.STRUCTURAL_EXCLUDED_DIRS) == generate_index._EXCLUDED_DIRS
+
+    def test_agents_md_13_2_exemption_matches_config(self):
+        """#247: the §13.2 exemption prose lists the same meta-files as the tool."""
+        from pathlib import Path
+
+        from playbook_validator import config
+
+        repo = Path(__file__).resolve().parents[2]
+        agents = repo / "AGENTS.md"
+        if not agents.is_file():
+            return
+        text = agents.read_text(encoding="utf-8")
+        for name in config.STRUCTURAL_EXCLUDED_FILENAMES:
+            assert name in text, f"AGENTS.md §13.2 must list the exempt meta-file {name}"

--- a/scripts/tests/test_validate_docs.py
+++ b/scripts/tests/test_validate_docs.py
@@ -92,6 +92,57 @@ class TestValidateDocFrontmatter:
         errors, warnings = validate_doc_frontmatter(md)
         assert any("load_priority" in e for e in errors)
 
+    def test_invalid_audience(self, tmp_path):
+        # #243: audience enum enforced (scalar or list)
+        md = tmp_path / "test.md"
+        md.write_text(
+            textwrap.dedent("""\
+            ---
+            title: "Test"
+            description: "A test"
+            status: canonical
+            tier: 2
+            audience: ["developers", "wizards"]
+            ---
+        """)
+        )
+        errors, warnings = validate_doc_frontmatter(md)
+        assert any("audience" in e and "wizards" in e for e in errors)
+
+    def test_valid_audience_agents(self, tmp_path):
+        # #243: 'agents' is a valid audience value (18 live docs use it)
+        md = tmp_path / "test.md"
+        md.write_text(
+            textwrap.dedent("""\
+            ---
+            title: "Test"
+            description: "A test"
+            status: canonical
+            tier: 2
+            audience: ["developers", "agents"]
+            ---
+        """)
+        )
+        errors, warnings = validate_doc_frontmatter(md)
+        assert not any("audience" in e for e in errors)
+
+    def test_invalid_review_cycle(self, tmp_path):
+        # #243: review_cycle enum enforced
+        md = tmp_path / "test.md"
+        md.write_text(
+            textwrap.dedent("""\
+            ---
+            title: "Test"
+            description: "A test"
+            status: canonical
+            tier: 2
+            review_cycle: fortnightly
+            ---
+        """)
+        )
+        errors, warnings = validate_doc_frontmatter(md)
+        assert any("review_cycle" in e and "fortnightly" in e for e in errors)
+
     def test_valid_optional_fields(self, tmp_path):
         md = tmp_path / "test.md"
         md.write_text(
@@ -611,6 +662,13 @@ class TestDocFreshness:
     def test_no_freshness_fields_ok(self, tmp_path):
         errors, warnings = self._check(tmp_path, "")
         assert errors == [] and warnings == []
+
+    def test_last_updated_without_cycle_warns(self, tmp_path):
+        # #249: last_updated but no review_cycle/stale_after → staleness cannot be
+        # derived, so the doc is silently exempt; surface the coverage gap.
+        errors, warnings = self._check(tmp_path, 'last_updated: "2026-01-01"\n')
+        assert errors == []
+        assert warnings and "staleness cannot be derived" in warnings[0] and "#249" in warnings[0]
 
     def test_real_repo_no_malformed_dates(self):
         """Live docs must have no malformed last_updated/stale_after (errors)."""

--- a/templates/PROJECT_PLAN.md
+++ b/templates/PROJECT_PLAN.md
@@ -4,7 +4,7 @@ description: "Starting point for a new federal coding project — fill this out 
 status: canonical
 tier: 3
 load_priority: reference-only
-audience: ["developers", "tech-leads", "managers"]
+audience: ["developers", "managers"]
 ---
 
 # Project Plan


### PR DESCRIPTION
Validator-integrity batch from the audit epic #232 — four validators that passed CI while structurally unable to catch what they claim. **3/3 consensus** (architect/security/scope-steward). No behavioral rule changed except a §13.2 doc clarification that matches existing tool behavior.

## #248 — two divergent "structural file" exclusion lists
`validate_docs` (10 filenames / 8 dirs) and `generate_index` (5 / 4) each hardcoded their own list, so a file could be **indexed by one tool and never validated by the other**. Real symptom: `templates/PROJECT_PLAN.md` shipped an invalid `audience` value into `INDEX.yaml` that the frontmatter validator couldn't reach. Single-sourced both into `config.STRUCTURAL_EXCLUDED_FILENAMES` / `STRUCTURAL_EXCLUDED_DIRS`; added a **drift-guard test** (set-equality across both modules) so they can't re-diverge.

## #243 — declared-but-unenforced frontmatter enums
`audience` / `review_cycle` enums lived in config but `validate_docs` never checked them. Now enforced (`audience` = scalar or list). The enum was **also wrong**: `agents` (used by 18 docs) was missing — added it. The 2 files using the non-existent `tech-leads` are fixed to `managers`. Tests: invalid audience, valid `agents`, invalid review_cycle.

## #249 — staleness rule covered only 11 of ~41 docs
It fired only when a doc had **both** `last_updated` and `review_cycle`; everything else was silently exempt. Now emits a **coverage-gap WARNING** when `last_updated` is present without `review_cycle`/`stale_after`, and backfilled `review_cycle: quarterly` on the 4 docs that had `last_updated` but no cycle.

## #247 — §13.2 prose vs tool reality
"All `.md` content files MUST include frontmatter" was unconditional while the tool exempts 10 meta-files. Reconciled the prose to list the exempt meta-files + point at the config single source; test asserts §13.2 names every exempt file. Bumped `last_updated` + Version History row.

## Verification
`make validate` · `generate-index --check` · **542 tests** (was 536) · `ruff check`/`format` all green. `.agents/` added to doc-discovery exclusions (validated by `validate-skills`). `make generate` regenerated INDEX/counts.

## Deferred (own PRs, correctly not batched)
- **#259** dependency lock file — its own PR; **gates #263** (pre-deploy advisory→gating). Direction chosen: commit the existing `uv.lock` (`git add -f`; it's hidden only by a *global* `~/.gitignore`, not any repo file).
- **#261** vestigial `config.py` constants — needs a per-constant WIRE-vs-DELETE decision.

Refs #232 #243 #247 #248 #249

AI-assisted (OpenCode).